### PR TITLE
DDP-4815 care evolve order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
+tcell
+appengine/*.conf
+appengine/deploy/lib
+appengine/deploy/*.conf
+appengine/deploy/tcell/*
+
 # IDEs and editors
 .idea
 target

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # Prerequisites
 1. [Maven 3](https://maven.apache.org/download.cgi)
 2. OpenJDK 11
+3. [gcloud CLI](https://cloud.google.com/sdk)
 ```
 brew tap homebrew/cask-versions
 brew cask install java11
@@ -28,14 +29,16 @@ To download this dependency, generate a github token and add it to your `~/.m2/s
 
 ````
 
-# Vault
-From within the top level directory, run the `render-templates.sh` script to generate `vault.conf`:
-```shell
-ENVIRONMENT=dev
-docker run --rm -v $PWD:/working -e VAULT_TOKEN=$(cat ~/.vault-token) -e ENVIRONMENT=$ENVIRONMENT -e OUT_PATH=./config -e INPUT_PATH=./config broadinstitute/dsde-toolbox:dev render-templates.sh
+# Secrets
+DSM uses GCP's [secret manager (SM)](https://cloud.google.com/secret-manager) to store credentials.
+
+To read secrets for a specific environment:
+```
+gcloud --project=${PROJECT_ID} secrets versions access latest --secret="${CONFIG_SECRETS}" > config/vault.conf
 ```
 This will put `vault.conf` into the `config` dir.  `DSMServer` will look at `conf/vault.conf` at boot time.  **Do not
 commit any generated vault.conf files!**
+
 
 # Getting something up and running
 This repo has a starter `DSMServer` app.  To setup the code in Intellj, click `File->New->Project From Existing Sources`
@@ -52,3 +55,15 @@ This repo contains backend code, but to serve out static assets, you can use env
 to serve out javascript, html, css, etc. via spark.  If you've checked out the [front end code](https://github.com/broadinstitute/ddp-dsm-ui) at `/foo/bar`
 on your local machine, then you can set `-Dserver.static_content_source=/foo/bar` when running `DSMServer` and the app should be visible on
 [localhost](http://localhost:4567).
+
+# Building and deploying
+To deploy to a specific project, just run the `build-and-deploy` script, which takes two args: the name of a project and the name
+of the GCP secret to read from said project.  To deploy to dev:
+
+```
+cd appengine/deploy
+./build-and-deploy.sh broad-ddp-dev study-manager-config
+```
+
+# Viewing Logs
+One way to view logs is via the [GCP console](https://console.cloud.google.com/logs/viewer).  Drill into `GAE Application -> study-manager-backend -> version`.

--- a/README.md
+++ b/README.md
@@ -1,53 +1,32 @@
-# Backend of the DDP Sample Management App (DSM)
-
-This is our first DDP backend app with a well structured dependency on https://github.com/broadinstitute/ddp-backend-core
+# Backend of the DDP Study Management App (DSM)
 
 # Prerequisites
 1. [Maven 3](https://maven.apache.org/download.cgi)
-2. [JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
+2. OpenJDK 11
+```
+brew tap homebrew/cask-versions
+brew cask install java11
+```
 
 # Setting up maven
-In addition to the usual public repos, we have an internal repo: [broad-internal artifactory](http://artifactory.broadinstitute.org).  This is where our DDP artifacts will live.
+In addition to the usual public repos, we use github package manager for the older lddp core dependency.
 
-To enable this repo, edit your `settings.xml` file so that it includes the following:
+To download this dependency, generate a github token and add it to your `~/.m2/settings.xml`:
 
 ````
 <settings>
-    <localRepository>${user.home}/.m3/repository</localRepository>
-
-    <profiles>
-      <profile>
-	<id>PERSONAL</id>
-	<repositories>
-	  <repository>
-            <id>broad-artifactory-release-local</id>
-            <name>artifactory-releases</name>
-            <url>http://artifactory.broadinstitute.org/artifactory/libs-release-local</url>
-	  </repository>
-	</repositories>
-      </profile>
-    </profiles>
-
-     <activeProfiles>
-        <activeProfile>PERSONAL</activeProfile>
-     </activeProfiles>
-
-     <servers>
+   ...
+   <servers>
        <server>
-	 <id>broad-artifactory-release-local</id>
-	 <username>[YOUR ARTIFACTORY USERNAME]</username>
-	 <password>[YOUR *encrypted* ARTIFACTORY PASSWORD]</password>
-	 </server>
+         <id>github</id>
+         <username>...github username...</username>
+         <password>...github token...</password>
+       </server>
      </servers>
-
+     ...
 </settings>
 
 ````
-
-#Artifactory setup
-To get your username and password for artifactory, get in touch with Zim or email help@broad and tell them you need access to the "ddp" group in artifactory.
-
-Once you've got an account, login to [artifactory](https://artifactory.broadinstitute.org), click on your username in the upper right corner, and copy the "encrypted password" field from the form into the `password` field in `settings.xml`.  **Remember: this is the _encrypted_ version of your password.**
 
 # Vault
 From within the top level directory, run the `render-templates.sh` script to generate `vault.conf`:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,18 @@ To read secrets for a specific environment:
 gcloud --project=${PROJECT_ID} secrets versions access latest --secret="${CONFIG_SECRETS}" > config/vault.conf
 ```
 This will put `vault.conf` into the `config` dir.  `DSMServer` will look at `conf/vault.conf` at boot time.  **Do not
-commit any generated vault.conf files!**
+commit any generated .conf files!**
+
+To seed configuration values for local development, run `render-testing-configs.sh`.   This will put
+various `*.conf` files into the `/config` dir.  **Do not commit any generated .conf files!**
+
+# Running Tests
+Point your test configuration at the `test-log4j.xml` file and set the fallback config file:
+
+```
+export TEST_CONFIG_FILE=config/test-config.conf
+java -Dlog4j.configuration=test-log4j.xml ...
+```
 
 
 # Getting something up and running

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ To download this dependency, generate a github token and add it to your `~/.m2/s
      	</repositories>
          </profile>
        </profiles>
+       
+       ...
+       
+       
 </settings>
 
 ````

--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ To download this dependency, generate a github token and add it to your `~/.m2/s
 
 ````
 <settings>
+   
    ...
+   
+    <activeProfiles>
+       <activeProfile>github</activeProfile>
+     </activeProfiles>
+   
+   ...
+   
    <servers>
        <server>
          <id>github</id>
@@ -24,7 +32,27 @@ To download this dependency, generate a github token and add it to your `~/.m2/s
          <password>...github token...</password>
        </server>
      </servers>
+     
      ...
+     
+     <profiles>
+         <profile>
+           <id>github</id>
+           <repositories>
+             <repository>
+               <id>central</id>
+               <url>https://repo1.maven.org/maven2</url>
+               <releases><enabled>true</enabled></releases>
+               <snapshots><enabled>true</enabled></snapshots>
+             </repository>
+             <repository>
+               <id>github</id>
+               <name>GitHub OWNER Apache Maven Packages</name>
+               <url>https://maven.pkg.github.com/broadinstitute/ddp-study-manager</url>
+               </repository>
+     	</repositories>
+         </profile>
+       </profiles>
 </settings>
 
 ````

--- a/appengine/deploy/.gcloudignore
+++ b/appengine/deploy/.gcloudignore
@@ -1,0 +1,19 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Target directory for maven builds
+target/
+# Build directory for gradle builds
+build/

--- a/appengine/deploy/StudyManager.yaml
+++ b/appengine/deploy/StudyManager.yaml
@@ -1,0 +1,15 @@
+service: study-manager-backend
+runtime: java11
+instance_class: B4
+
+manual_scaling:
+  instances: 1
+
+network:
+  instance_tag: study-manager
+
+entrypoint: java -cp dsm-backend-SNAPSHOT.jar -javaagent:tcell/tcellagent.jar -Xmx820m -Xmx820m -Dconfig.file=vault.conf org.broadinstitute.dsm.DSMServer
+
+env_variables:
+  TCELL_AGENT_HOST_IDENTIFIER: study-manager
+  TCELL_AGENT_CACHE_DIR: /tmp

--- a/appengine/deploy/StudyManager.yaml
+++ b/appengine/deploy/StudyManager.yaml
@@ -8,7 +8,7 @@ manual_scaling:
 network:
   instance_tag: study-manager
 
-entrypoint: java -cp dsm-backend-SNAPSHOT.jar -javaagent:tcell/tcellagent.jar -Xmx820m -Xmx820m -Dconfig.file=vault.conf org.broadinstitute.dsm.DSMServer
+entrypoint: java -jar DSMServer.jar -javaagent:tcell/tcellagent.jar -Xms820m -Xmx820m -Dconfig.file=vault.conf
 
 env_variables:
   TCELL_AGENT_HOST_IDENTIFIER: study-manager

--- a/appengine/deploy/StudyManager.yaml
+++ b/appengine/deploy/StudyManager.yaml
@@ -8,7 +8,7 @@ manual_scaling:
 network:
   instance_tag: study-manager
 
-entrypoint: java -jar DSMServer.jar -javaagent:tcell/tcellagent.jar -Xms820m -Xmx820m -Dlog4j.configurationFile=log4j.xml -Dconfig.file=vault.conf
+entrypoint: java -javaagent:tcell/tcellagent.jar -Xms820m -Xmx820m -Dlog4j.configurationFile=log4j.xml -jar DSMServer.jar
 
 env_variables:
   TCELL_AGENT_HOST_IDENTIFIER: study-manager

--- a/appengine/deploy/StudyManager.yaml
+++ b/appengine/deploy/StudyManager.yaml
@@ -8,7 +8,7 @@ manual_scaling:
 network:
   instance_tag: study-manager
 
-entrypoint: java -jar DSMServer.jar -javaagent:tcell/tcellagent.jar -Xms820m -Xmx820m -Dconfig.file=vault.conf
+entrypoint: java -jar DSMServer.jar -javaagent:tcell/tcellagent.jar -Xms820m -Xmx820m -Dlog4j.configurationFile=log4j.xml -Dconfig.file=vault.conf
 
 env_variables:
   TCELL_AGENT_HOST_IDENTIFIER: study-manager

--- a/appengine/deploy/build-and-deploy.sh
+++ b/appengine/deploy/build-and-deploy.sh
@@ -15,6 +15,7 @@ rm -fr lib
 mkdir -p lib
 mvn -f ../../pom.xml dependency:copy-dependencies -DoutputDirectory=./appengine/deploy/lib
 cp ../../target/DSMServer.jar .
+cp ../../src/main/resources/log4j.xml .
 
 echo "Downloading and configuring tcell"
 gsutil cat gs://ddp-tcell/tcell-1.11.0.tar.gz | tar -xf -

--- a/appengine/deploy/build-and-deploy.sh
+++ b/appengine/deploy/build-and-deploy.sh
@@ -2,9 +2,10 @@
 set -eu -o pipefail
 
 PROJECT_ID=$1
+CONFIG_SECRETS=$2
 
 echo "Reading configs from cloud secret manager"
-gcloud --project=${PROJECT_ID} secrets versions access latest --secret="study-manager-config" > vault.conf
+gcloud --project=${PROJECT_ID} secrets versions access latest --secret="${CONFIG_SECRETS}" > vault.conf
 
 #  run the build
 echo "Running maven"

--- a/appengine/deploy/build-and-deploy.sh
+++ b/appengine/deploy/build-and-deploy.sh
@@ -14,7 +14,7 @@ mvn -DskipTests clean install package -f ../../pom.xml
 rm -fr lib
 mkdir -p lib
 mvn -f ../../pom.xml dependency:copy-dependencies -DoutputDirectory=./appengine/deploy/lib
-cp ../../target/dsm-backend-SNAPSHOT.jar .
+cp ../../target/DSMServer.jar .
 
 echo "Downloading and configuring tcell"
 gsutil cat gs://ddp-tcell/tcell-1.11.0.tar.gz | tar -xf -

--- a/appengine/deploy/build-and-deploy.sh
+++ b/appengine/deploy/build-and-deploy.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+PROJECT_ID=$1
+
+echo "Reading configs from cloud secret manager"
+gcloud --project=${PROJECT_ID} secrets versions access latest --secret="study-manager-config" > vault.conf
+
+#  run the build
+echo "Running maven"
+mvn -DskipTests clean install package -f ../../pom.xml
+
+# bundling dependencies
+rm -fr lib
+mkdir -p lib
+mvn -f ../../pom.xml dependency:copy-dependencies -DoutputDirectory=./appengine/deploy/lib
+cp ../../target/dsm-backend-SNAPSHOT.jar .
+
+echo "Downloading and configuring tcell"
+gsutil cat gs://ddp-tcell/tcell-1.11.0.tar.gz | tar -xf -
+gcloud --project=${PROJECT_ID} secrets versions access latest --secret="study-manager-tcell" >  tcell/tcell_agent.config
+
+# deploy to gae
+gcloud app deploy -q --stop-previous-version --project ${PROJECT_ID} StudyManager.yaml

--- a/appengine/deploy/build-and-deploy.sh
+++ b/appengine/deploy/build-and-deploy.sh
@@ -22,4 +22,4 @@ gsutil cat gs://ddp-tcell/tcell-1.11.0.tar.gz | tar -xf -
 gcloud --project=${PROJECT_ID} secrets versions access latest --secret="study-manager-tcell" >  tcell/tcell_agent.config
 
 # deploy to gae
-gcloud app deploy -q --stop-previous-version --project ${PROJECT_ID} StudyManager.yaml
+gcloud app deploy -q --stop-previous-version --promote --project ${PROJECT_ID} StudyManager.yaml

--- a/pom.xml
+++ b/pom.xml
@@ -17,20 +17,13 @@
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>
             <version>2.8.0</version>
-            <exclusions>
-                <exclusion>
-                    <!-- this pom will declare the version of sparkjava -->
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>spark-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
 
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.18</version>
+            <version>8.0.20</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud.sql</groupId>
@@ -44,9 +37,9 @@
             <version>dsm_2.4_20190322a</version>
             <exclusions>
                 <exclusion>
-                    <!-- need this to to avoid http://www.slf4j.org/codes.html#multiple_bindings -->
+                    <!-- this pom will declare the version of sparkjava -->
                     <groupId>com.sparkjava</groupId>
-                    <artifactId>slf4j-simple</artifactId>
+                    <artifactId>spark-core</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -194,6 +187,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
+                    <finalName>DSMServer</finalName>
                     <archive>
                         <manifest>
                             <addClasspath>true</addClasspath>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,20 @@
     <dependencies>
 
         <dependency>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>2.8.0</version>
+            <exclusions>
+                <exclusion>
+                    <!-- this pom will declare the version of sparkjava -->
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>spark-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+
+        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>8.0.18</version>
@@ -28,6 +42,13 @@
             <groupId>org.broadinstitute.ddp</groupId>
             <artifactId>lddp</artifactId>
             <version>dsm_2.4_20190322a</version>
+            <exclusions>
+                <exclusion>
+                    <!-- need this to to avoid http://www.slf4j.org/codes.html#multiple_bindings -->
+                    <groupId>com.sparkjava</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -136,6 +157,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlets</artifactId>
+            <version>9.4.28.v20200408</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,19 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-
+    <packaging>jar</packaging>
     <dependencies>
+
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.18</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud.sql</groupId>
+            <artifactId>mysql-socket-factory-connector-j-8</artifactId>
+            <version>1.0.15</version>
+        </dependency>
 
         <dependency>
             <groupId>org.broadinstitute.ddp</groupId>
@@ -152,72 +163,20 @@
                 </configuration>
             </plugin>
             <plugin>
-	      <!-- used to generate single jar file for deployment -->
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.3</version>
+                <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
-                    <finalName>DSMServer</finalName>
-                    <transformers>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
                             <mainClass>org.broadinstitute.dsm.DSMServer</mainClass>
-                            <manifestEntries>
-                                <Main-Class>org.broadinstitute.dsm.DSMServer</Main-Class>
-                            </manifestEntries>
-                        </transformer>
-                    </transformers>
+                            <classpathPrefix>lib/</classpathPrefix>
+                        </manifest>
+                    </archive>
                 </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.eluder.coveralls</groupId>
-                <artifactId>coveralls-maven-plugin</artifactId>
-                <version>4.1.0</version>
-                <configuration>
-                    <repoToken>d547siXOmw6GTfensdfl6RGVSdRqjb05Z</repoToken>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
-                <configuration>
-                    <format>xml</format>
-                    <maxmem>256m</maxmem>
-                    <!-- aggregated reports for multi-module projects -->
-                    <aggregate>true</aggregate>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.javalite</groupId>
-                <artifactId>activejdbc-instrumentation</artifactId>
-                <version>1.4.11</version>
-                <executions>
-                    <execution>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>instrument</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>
 </project>
+
+<!-- arz remove ruby, postgress, activejdbc -->

--- a/pom.xml
+++ b/pom.xml
@@ -27,10 +27,9 @@
 
         <dependency>
             <groupId>org.broadinstitute.ddp</groupId>
-            <artifactId>lddp</artifactId>
-            <version>dsm_2.4_20190322a</version>
+            <artifactId>ldd-backend</artifactId>
+            <version>dsm_2.4_20200713b</version>
         </dependency>
-
 
         <dependency>
             <groupId>mysql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,12 +45,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.sparkjava</groupId>
-            <artifactId>spark-core</artifactId>
-            <version>2.8.0</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-oauth2</artifactId>
             <version>v2-rev113-1.22.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
         <dependency>
             <groupId>org.broadinstitute.ddp</groupId>
-            <artifactId>lddp-backend</artifactId>
+            <artifactId>lddp</artifactId>
             <version>dsm_2.4_20190322a</version>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.broadinstitute.ddp</groupId>
             <artifactId>ldd-backend</artifactId>
-            <version>dsm_2.4_20200713b</version>
+            <version>dsm_2.4_20200717</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,25 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    <packaging>jar</packaging>
     <dependencies>
 
         <dependency>
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>
             <version>2.8.0</version>
+            <exclusions>
+                <exclusion>
+                    <!-- need this to to avoid http://www.slf4j.org/codes.html#multiple_bindings -->
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.broadinstitute.ddp</groupId>
+            <artifactId>lddp-backend</artifactId>
+            <version>dsm_2.4_20190322a</version>
         </dependency>
 
 
@@ -25,6 +37,7 @@
             <artifactId>mysql-connector-java</artifactId>
             <version>8.0.20</version>
         </dependency>
+
         <dependency>
             <groupId>com.google.cloud.sql</groupId>
             <artifactId>mysql-socket-factory-connector-j-8</artifactId>
@@ -32,16 +45,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.broadinstitute.ddp</groupId>
-            <artifactId>lddp</artifactId>
-            <version>dsm_2.4_20190322a</version>
-            <exclusions>
-                <exclusion>
-                    <!-- this pom will declare the version of sparkjava -->
-                    <groupId>com.sparkjava</groupId>
-                    <artifactId>spark-core</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>2.8.0</version>
         </dependency>
 
         <dependency>
@@ -104,10 +110,8 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.2</version>
-            <scope>provided</scope>
+            <version>1.18.12</version>
         </dependency>
-
         <!-- liquibase -->
         <dependency>
             <groupId>org.liquibase</groupId>
@@ -152,9 +156,39 @@
         </dependency>
 
         <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>auth0</artifactId>
+            <version>1.8.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlets</artifactId>
             <version>9.4.28.v20200408</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>jwks-rsa</artifactId>
+            <version>0.2.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>java-jwt</artifactId>
+            <version>3.10.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
         </dependency>
 
     </dependencies>
@@ -177,10 +211,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.8.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>11</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -150,33 +150,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.auth0</groupId>
-            <artifactId>auth0</artifactId>
-            <version>1.8.0</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlets</artifactId>
             <version>9.4.28.v20200408</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.auth0</groupId>
-            <artifactId>jwks-rsa</artifactId>
-            <version>0.2.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.auth0</groupId>
-            <artifactId>java-jwt</artifactId>
-            <version>3.10.3</version>
         </dependency>
 
         <dependency>

--- a/render-testing-configs.sh
+++ b/render-testing-configs.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+PROJECT_ID=$1
+
+echo "Reading ellkay config from cloud secret manager"
+CONFIG_SECRETS=ellkay
+gcloud --project=${PROJECT_ID} secrets versions access latest --secret="${CONFIG_SECRETS}" > config/ellkay.conf
+
+echo "Reading test-config from cloud secret manager"
+CONFIG_SECRETS=dsm-test-config
+gcloud --project=${PROJECT_ID} secrets versions access latest --secret="${CONFIG_SECRETS}" > config/test-config.conf

--- a/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -119,6 +119,12 @@ public class DSMServer extends BasicServer {
             if (StringUtils.isNotBlank(cfg.getString("portal.googleProjectCredentials"))) {
                 System.setProperty("GOOGLE_APPLICATION_CREDENTIALS", cfg.getString("portal.googleProjectCredentials"));
             }
+
+            String preferredSourceIPHeader = null;
+            if (cfg.hasPath(ApplicationConfigConstants.PREFERRED_SOURCE_IP_HEADER)) {
+                preferredSourceIPHeader = cfg.getString(ApplicationConfigConstants.PREFERRED_SOURCE_IP_HEADER);
+            }
+            JettyConfig.setupJetty(preferredSourceIPHeader);
             DSMServer server = new DSMServer();
             server.configureServer(cfg);
             isReady.set(true);
@@ -144,14 +150,11 @@ public class DSMServer extends BasicServer {
 
         logger.info("Using port {}", port);
         port(port);
+
         registerAppEngineStartupCallback(bootTimeoutSeconds);
         setupDB(config);
-        setupRouting(config);
-        String preferredSourceIPHeader = null;
-        if (config.hasPath(ApplicationConfigConstants.PREFERRED_SOURCE_IP_HEADER)) {
-            preferredSourceIPHeader = config.getString(ApplicationConfigConstants.PREFERRED_SOURCE_IP_HEADER);
-        }
-        JettyConfig.setupJetty(preferredSourceIPHeader);
+        setupCustomRouting(config);
+
         enableCORS(String.join(",", CORS_HTTP_METHODS), String.join(",", CORS_HTTP_HEADERS));
     }
 

--- a/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -153,6 +153,7 @@ public class DSMServer extends BasicServer {
 
         registerAppEngineStartupCallback(bootTimeoutSeconds);
         setupDB(config);
+        // don't run superclass routing--it won't work with JettyConfig changes for capturing proper IP address in GAE
         setupCustomRouting(config);
 
         enableCORS(String.join(",", CORS_HTTP_METHODS), String.join(",", CORS_HTTP_HEADERS));

--- a/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -39,6 +39,7 @@ import org.quartz.impl.StdSchedulerFactory;
 import org.quartz.impl.matchers.KeyMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import spark.Request;
 import spark.Response;
 import spark.Route;
@@ -162,6 +163,10 @@ public class DSMServer extends BasicServer {
         if (StringUtils.isBlank(bspSecret)) {
             throw new RuntimeException("No secret supplied for BSP endpoint, system exiting.");
         }
+
+        //  capture basic route info for logging
+        before("*", new LoggingFilter());
+        afterAfter((req, res)-> MDC.clear());
 
         before(API_ROOT + RoutePath.BSP_KIT_QUERY_PATH, (req, res) -> {
             if (!new JWTRouteFilter(bspSecret, null).isAccessAllowed(req)) {

--- a/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -699,6 +699,9 @@ public class DSMServer extends BasicServer {
             if (accessControlRequestMethod != null) {
                 response.header("Access-Control-Allow-Methods", accessControlRequestMethod);
             }
+            if (accessControlRequestMethod != null || accessControlRequestHeaders != null) {
+                response.header("Access-Control-Max-Age", "172800");
+            }
 
             return "OK";
         });

--- a/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -146,7 +146,8 @@ public class DSMServer extends BasicServer {
         port(port);
         registerAppEngineStartupCallback(bootTimeoutSeconds);
         setupDB(config);
-        setupRouting(config);
+        // don't run superclass routing--it won't work with JettyConfig changes for capturing proper IP address in GAE
+        setupCustomRouting(config);
         String preferredSourceIPHeader = null;
         if (config.hasPath(ApplicationConfigConstants.PREFERRED_SOURCE_IP_HEADER)) {
             preferredSourceIPHeader = config.getString(ApplicationConfigConstants.PREFERRED_SOURCE_IP_HEADER);

--- a/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -92,6 +92,7 @@ public class DSMServer extends BasicServer {
     public static final String CONTAINER = "Container";
     public static final String RECEIVER = "Receiver";
     public static final String ADDITIONAL_CRON_EXPRESSION = "AdditionalCronExpression";
+    public static final String GCP_PATH_TO_SERVICE_ACCOUNT = "portal.googleProjectCredentials";
 
     private static Map<String, MBCParticipant> mbcParticipants = new HashMap<>();
     private static Map<String, MBCInstitution> mbcInstitutions = new HashMap<>();
@@ -107,6 +108,7 @@ public class DSMServer extends BasicServer {
     public static void main(String[] args) {
         // immediately lock isReady so that ah/start route will wait
         synchronized (isReady) {
+            logger.info("Starting up DSM");
             //config without secrets
             Config cfg = ConfigFactory.load();
             //secrets from vault in a config file
@@ -116,8 +118,10 @@ public class DSMServer extends BasicServer {
             logger.info("Reading config values from "+vaultConfig.getAbsolutePath());
             cfg = cfg.withFallback(ConfigFactory.parseFile(vaultConfig));
 
-            if (StringUtils.isNotBlank(cfg.getString("portal.googleProjectCredentials"))) {
-                System.setProperty("GOOGLE_APPLICATION_CREDENTIALS", cfg.getString("portal.googleProjectCredentials"));
+            if (cfg.hasPath(GCP_PATH_TO_SERVICE_ACCOUNT)) {
+                if (StringUtils.isNotBlank(cfg.getString("portal.googleProjectCredentials"))) {
+                    System.setProperty("GOOGLE_APPLICATION_CREDENTIALS", cfg.getString("portal.googleProjectCredentials"));
+                }
             }
 
             String preferredSourceIPHeader = null;
@@ -128,6 +132,7 @@ public class DSMServer extends BasicServer {
             DSMServer server = new DSMServer();
             server.configureServer(cfg);
             isReady.set(true);
+            logger.info("DSM Startup Complete");
         }
     }
 

--- a/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -66,11 +66,6 @@ public class DSMServer extends BasicServer {
 
     private static final Logger logger = LoggerFactory.getLogger(DSMServer.class);
 
-    private static final List<String> ALLOWED_ORIGINS = Arrays.asList("http://localhost:4200","https://dsm.datadonationplatform.org",
-            "https://dsm.dev.datadonationplatform.org","https://dsm.test.datadonationplatform.org",
-            "https://dsm.staging.datadonationplatform.org","https://dsm-dev.datadonationplatform.org",
-            "https://dsm-test.datadonationplatform.org","https://dsm-staging.datadonationplatform.org");
-
     private static final String API_ROOT = "/api/";
     private static final String UI_ROOT = "/ui/";
 
@@ -161,7 +156,8 @@ public class DSMServer extends BasicServer {
         // don't run superclass routing--it won't work with JettyConfig changes for capturing proper IP address in GAE
         setupCustomRouting(config);
 
-        enableCORS(String.join(",", CORS_HTTP_METHODS), String.join(",", CORS_HTTP_HEADERS));
+        List<String> allowedOrigins = config.getStringList(ApplicationConfigConstants.CORS_ALLOWED_ORIGINS);
+        enableCORS(StringUtils.join(allowedOrigins, ","), String.join(",", CORS_HTTP_METHODS), String.join(",", CORS_HTTP_HEADERS));
     }
 
     protected void setupCustomRouting(@NonNull Config cfg) {
@@ -754,8 +750,7 @@ public class DSMServer extends BasicServer {
         }
     }
 
-    // todo  arz fixme read from config file
-    private static void enableCORS(String methods, String headers) {
+    protected static void enableCORS(String allowedOrigins, String methods, String headers) {
         Spark.options("/*", (request, response) -> {
             String accessControlRequestHeaders = request.headers("Access-Control-Request-Headers");
             if (accessControlRequestHeaders != null) {
@@ -774,7 +769,7 @@ public class DSMServer extends BasicServer {
         });
         Spark.before((request, response) -> {
             String origin = request.headers("Origin");
-            response.header("Access-Control-Allow-Origin", ALLOWED_ORIGINS.contains(origin) ? origin :  "");
+            response.header("Access-Control-Allow-Origin", allowedOrigins.contains(origin) ? origin :  "");
             response.header("Access-Control-Request-Method", methods);
             response.header("Access-Control-Allow-Headers", headers);
             response.header("Access-Control-Allow-Credentials", "true");

--- a/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -230,6 +230,8 @@ public class DSMServer extends BasicServer {
 
         get("/info/" + RoutePath.PARTICIPANT_STATUS_REQUEST, new ParticipantStatusRoute(), new JsonNullTransformer());
 
+        post(appRoute + RoutePath.BATCH_KITS_REQUEST, new BatchKitsRoute(), new JsonNullTransformer());
+
         // requests from frontend
         before(UI_ROOT + "*", (req, res) -> {
             if (!"OPTIONS".equals(req.requestMethod())) {

--- a/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -203,6 +203,8 @@ public class DSMServer extends BasicServer {
         get(appRoute + RoutePath.DRUG_LIST_REQUEST, drugRoute, new JsonTransformer());
         get(UI_ROOT + RoutePath.DRUG_LIST_REQUEST, drugRoute, new JsonTransformer());
 
+        post(appRoute + RoutePath.BATCH_KITS_REQUEST, new BatchKitsRoute(), new JsonTransformer());
+
         CancerRoute cancerRoute = new CancerRoute();
         get(appRoute + RoutePath.CANCER_LIST_REQUEST, cancerRoute, new JsonTransformer());
         get(UI_ROOT + RoutePath.CANCER_LIST_REQUEST, cancerRoute, new JsonTransformer());
@@ -230,7 +232,7 @@ public class DSMServer extends BasicServer {
 
         get("/info/" + RoutePath.PARTICIPANT_STATUS_REQUEST, new ParticipantStatusRoute(), new JsonNullTransformer());
 
-        post(appRoute + RoutePath.BATCH_KITS_REQUEST, new BatchKitsRoute(), new JsonNullTransformer());
+
 
         // requests from frontend
         before(UI_ROOT + "*", (req, res) -> {
@@ -771,7 +773,7 @@ public class DSMServer extends BasicServer {
         });
         Spark.before((request, response) -> {
             String origin = request.headers("Origin");
-            response.header("Access-Control-Allow-Origin", allowedOrigins.contains(origin) ? origin :  "");
+            response.header("Access-Control-Allow-Origin", ( StringUtils.isNotBlank(origin) && allowedOrigins.contains(origin) )? origin :  "");
             response.header("Access-Control-Request-Method", methods);
             response.header("Access-Control-Allow-Headers", headers);
             response.header("Access-Control-Allow-Credentials", "true");

--- a/src/main/java/org/broadinstitute/dsm/careevolve/AOE.java
+++ b/src/main/java/org/broadinstitute/dsm/careevolve/AOE.java
@@ -1,0 +1,39 @@
+package org.broadinstitute.dsm.careevolve;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Ask at Order Entry tuple, which has a code,
+ * description, and value
+ */
+public class AOE {
+
+    @SerializedName("AOECode")
+    private String code;
+
+    @SerializedName("AOEDescription")
+    private String description;
+
+    @SerializedName("AOEAnswer")
+    private String value;
+
+    public AOE(String code, String description, String value) {
+        this.code = code;
+        this.description = description;
+        this.value = value;
+    }
+
+    /**
+     * Creates a list of AOES used for TestBoston
+     */
+    public static List<AOE> forTestBoston(String userGuid, String kitGuid) {
+        List<AOE> aoes = new ArrayList<>();
+        aoes.add(new AOE("Q1","Type of Swab","AN SWAB"));
+        aoes.add(new AOE("PEPPER_USER_ID","Pepper User Guid",userGuid));
+        aoes.add(new AOE("PEPPER_KIT_ID","Pepper Kit Guid",kitGuid));
+        return aoes;
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/careevolve/Address.java
+++ b/src/main/java/org/broadinstitute/dsm/careevolve/Address.java
@@ -1,0 +1,29 @@
+package org.broadinstitute.dsm.careevolve;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Address {
+
+    @SerializedName("Line1")
+    private String line1;
+
+    @SerializedName("Line2")
+    private String line2;
+
+    @SerializedName("City")
+    private String city;
+
+    @SerializedName("State")
+    private String state;
+
+    @SerializedName("ZipCode")
+    private String zipCode;
+
+    public Address(String line1, String line2, String city, String state, String zipCode) {
+        this.line1 = line1;
+        this.line2 = line2;
+        this.city = city;
+        this.state = state;
+        this.zipCode = zipCode;
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/careevolve/AuthenticatedMessage.java
+++ b/src/main/java/org/broadinstitute/dsm/careevolve/AuthenticatedMessage.java
@@ -1,0 +1,17 @@
+package org.broadinstitute.dsm.careevolve;
+
+import com.google.gson.annotations.SerializedName;
+
+public class AuthenticatedMessage {
+
+    @SerializedName("request")
+    private Message message;
+
+    @SerializedName("authentication")
+    private Authentication authentication;
+
+    public AuthenticatedMessage(Authentication auth, Message message) {
+        this.authentication = auth;
+        this.message = message;
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/careevolve/Authentication.java
+++ b/src/main/java/org/broadinstitute/dsm/careevolve/Authentication.java
@@ -1,0 +1,17 @@
+package org.broadinstitute.dsm.careevolve;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Authentication {
+
+    @SerializedName("ServiceKey")
+    private final String serviceKey;
+
+    @SerializedName("SubscriberKey")
+    private final String subscriberKey;
+
+    public Authentication(String subscriberKey, String serviceKey) {
+        this.subscriberKey = subscriberKey;
+        this.serviceKey = serviceKey;
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/careevolve/Covid19OrderRegistrar.java
+++ b/src/main/java/org/broadinstitute/dsm/careevolve/Covid19OrderRegistrar.java
@@ -1,0 +1,59 @@
+package org.broadinstitute.dsm.careevolve;
+
+import java.io.IOException;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.client.fluent.Response;
+import org.apache.http.entity.ContentType;
+import org.apache.http.util.EntityUtils;
+import org.broadinstitute.dsm.exception.CareEvolveException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Places orders with CareEvolve for COVID-19 virology
+ */
+public class Covid19OrderRegistrar {
+
+    private static final Logger logger = LoggerFactory.getLogger(Covid19OrderRegistrar.class);
+
+    private final String endpoint;
+
+    /**
+     * Create a new one that uses the given endpoint
+     * for placing orders
+     */
+    public Covid19OrderRegistrar(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    /**
+     * Order a test using the given auth and message details.
+     * Returns an {@link OrderResponse} when the order has been
+     * placed successfully.  Otherwise, an exception is thrown.
+     */
+    public OrderResponse orderTest(Authentication auth, Message message) throws IOException {
+        logger.info("About to send {} as {} to {}", message.getName(), endpoint);
+        AuthenticatedMessage careEvolveMessage = new AuthenticatedMessage(auth, message);
+
+        String json = new GsonBuilder().serializeNulls().setPrettyPrinting().create().toJson(careEvolveMessage);
+
+        Response response = Request.Post(endpoint).bodyString(json, ContentType.APPLICATION_JSON).execute();
+        HttpResponse httpResponse = response.returnResponse();
+
+        String responseString = EntityUtils.toString(httpResponse.getEntity());
+
+        if (httpResponse.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+            OrderResponse orderResponse = new Gson().fromJson(IOUtils.toString(httpResponse.getEntity().getContent()), OrderResponse.class);
+            return orderResponse;
+        } else {
+            logger.error("Order {} returned {} with {}", message.getName(), httpResponse.getStatusLine().getStatusCode(), responseString);
+            throw new CareEvolveException("CareEvolve returned " + httpResponse.getStatusLine().getStatusCode() + " with " + responseString);
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/careevolve/Message.java
+++ b/src/main/java/org/broadinstitute/dsm/careevolve/Message.java
@@ -1,0 +1,26 @@
+package org.broadinstitute.dsm.careevolve;
+
+import java.util.Base64;
+
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+
+public class Message {
+
+    @SerializedName("Body")
+    private String body;
+
+    @SerializedName("Name")
+    private String name;
+
+    public Message(Order order, String messageName) {
+        String json = new GsonBuilder().serializeNulls().create().toJson(order);
+        // as per CareEvolve's docs, the body field should be base64 encoded json
+        this.body = new String(Base64.getEncoder().encode(json.getBytes()));
+        this.name = messageName;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/careevolve/Order.java
+++ b/src/main/java/org/broadinstitute/dsm/careevolve/Order.java
@@ -1,0 +1,42 @@
+package org.broadinstitute.dsm.careevolve;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Order {
+
+    @SerializedName("AOEs")
+    private List<AOE> aoes = new ArrayList<>();
+
+    @SerializedName("collection")
+    private String collectionTime;
+
+    @SerializedName("patient")
+    private Patient patient;
+
+    @SerializedName("provider")
+    private Provider provider;
+
+    /**
+     * This is the label on the tube that will
+     * be scanned into Mercury during accessioning
+     */
+    @SerializedName("OrderId")
+    private String orderId;
+
+    @SerializedName("CareEvolveAccount")
+    private String account;
+
+    public Order(String account, Patient patient, Provider provider, List<AOE> aoes) {
+        this.account = account;
+        this.provider = provider;
+        this.aoes = aoes;
+        this.patient = patient;
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/careevolve/OrderResponse.java
+++ b/src/main/java/org/broadinstitute/dsm/careevolve/OrderResponse.java
@@ -1,0 +1,27 @@
+package org.broadinstitute.dsm.careevolve;
+
+import com.google.gson.annotations.SerializedName;
+
+public class OrderResponse {
+
+    @SerializedName("hl7AcknowledgementMessage")
+    private  String hl7Ack;
+
+    @SerializedName("handle")
+    private String handle;
+
+    @SerializedName("errorDetail")
+    private String error;
+
+    public String getHl7Ack() {
+        return hl7Ack;
+    }
+
+    public String getHandle() {
+        return handle;
+    }
+
+    public String getError() {
+        return error;
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/careevolve/Patient.java
+++ b/src/main/java/org/broadinstitute/dsm/careevolve/Patient.java
@@ -1,0 +1,50 @@
+package org.broadinstitute.dsm.careevolve;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Patient {
+
+    @SerializedName("PatientID")
+    private String patientId;
+
+    @SerializedName("LastName")
+    private String lastName;
+
+    @SerializedName("FirstName")
+    private String firstName;
+
+    // YYYY-MM-DD
+    @SerializedName("DateOfBirth")
+    private String dateOfBirth;
+
+    // cdc 1000-9 values
+    @SerializedName("race")
+    private String race;
+
+    @SerializedName("Ethnicity")
+    private String ethnicity;
+
+    @SerializedName("Gender")
+    private String gender;
+
+    @SerializedName("Address")
+    private Address address;
+
+    public Patient(String patientId,
+                   String firstName,
+                   String lastName,
+                   String dateOfBirth,
+                   String race,
+                   String ethnicity,
+                   String gender,
+                   Address address) {
+        this.patientId = patientId;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.dateOfBirth = dateOfBirth;
+        this.race = race;
+        this.ethnicity = ethnicity;
+        this.gender = gender;
+        this.address = address;
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/careevolve/Provider.java
+++ b/src/main/java/org/broadinstitute/dsm/careevolve/Provider.java
@@ -1,0 +1,24 @@
+package org.broadinstitute.dsm.careevolve;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Provider {
+
+    @SerializedName("FirstName")
+    private String firstName;
+
+    @SerializedName("LastName")
+    private String lastName;
+    private final String npi;
+
+    @SerializedName("NPI")
+    private String NPI;
+
+    public Provider(String firstName,
+                    String lastName,
+                    String npi) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.npi = npi;
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/db/KitDiscard.java
+++ b/src/main/java/org/broadinstitute/dsm/db/KitDiscard.java
@@ -300,7 +300,8 @@ public class KitDiscard {
         Map<Integer, String> users = UserUtil.getUserMap();
         SimpleResult results = inTransaction((conn) -> {
             SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement stmt = conn.prepareStatement(TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.GET_KIT_OF_EXITED_PARTICIPANTS) + QueryExtension.DISCARD_KIT_BY_DISCARD_ID)) {
+            try (PreparedStatement stmt = conn.prepareStatement(TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.GET_KIT_OF_EXITED_PARTICIPANTS) + QueryExtension.DISCARD_KIT_BY_DISCARD_ID,
+                    ResultSet.TYPE_SCROLL_SENSITIVE,ResultSet.CONCUR_READ_ONLY)) {
                 stmt.setString(1, kitDiscardId);
                 try (ResultSet rs = stmt.executeQuery()) {
                     rs.last();

--- a/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
+++ b/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
@@ -898,7 +898,7 @@ public class KitRequestShipping extends KitRequest {
 
     public static int getKitCounter(@NonNull Connection conn, String collaboratorSampleId, int kitTypeId) {
         String query = TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.GET_COUNT_KITS_WITH_SAME_COLLABORATOR_SAMPLE_ID_AND_KIT_TYPE).replace("%1", collaboratorSampleId);
-        try (PreparedStatement stmt = conn.prepareStatement(query)) {
+        try (PreparedStatement stmt = conn.prepareStatement(query,ResultSet.TYPE_SCROLL_SENSITIVE,ResultSet.CONCUR_READ_ONLY)) {
             stmt.setInt(1, kitTypeId);
             try (ResultSet rs = stmt.executeQuery()) {
                 rs.last();
@@ -1114,7 +1114,8 @@ public class KitRequestShipping extends KitRequest {
     public static void reactivateKitRequest(@NonNull String kitRequestId, String message) {
         SimpleResult results = inTransaction((conn) -> {
             SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement stmt = conn.prepareStatement(SQL_SELECT_KIT + QueryExtension.KIT_DEACTIVATED)) {
+            try (PreparedStatement stmt = conn.prepareStatement(SQL_SELECT_KIT + QueryExtension.KIT_DEACTIVATED,
+                    ResultSet.TYPE_SCROLL_SENSITIVE,ResultSet.CONCUR_READ_ONLY)) {
                 stmt.setString(1, kitRequestId);
                 try (ResultSet rs = stmt.executeQuery()) {
                     rs.last();

--- a/src/main/java/org/broadinstitute/dsm/db/KitStatus.java
+++ b/src/main/java/org/broadinstitute/dsm/db/KitStatus.java
@@ -9,7 +9,9 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.broadinstitute.ddp.db.TransactionWrapper.inTransaction;
 
@@ -20,6 +22,12 @@ public class KitStatus {
             "LEFT JOIN kit_type ty on (req.kit_type_id = ty.kit_type_id) LEFT JOIN ddp_kit_request_settings ks on (ks.ddp_instance_id = req.ddp_instance_id AND ks.kit_type_id = req.kit_type_id) " +
             "LEFT JOIN carrier_service cs on (ks.carrier_service_to_id = cs.carrier_service_id) WHERE req.ddp_participant_id = ? AND req.ddp_instance_id = ? AND kit.scan_date IS NOT NULL AND kit.deactivation_reason IS NULL";
 
+    private static final String SQL_SELECT_BATCH_SAMPLES_STATUS = "SELECT req.ddp_kit_request_id, req.ddp_participant_id , ty.kit_type_name, kit.scan_date, kit.receive_date, kit.tracking_to_id, kit.easypost_shipment_date, cs.carrier as carrierTo FROM ddp_kit_request req LEFT JOIN ddp_kit kit on (kit.dsm_kit_request_id = req.dsm_kit_request_id) " +
+            "LEFT JOIN kit_type ty on (req.kit_type_id = ty.kit_type_id) LEFT JOIN ddp_kit_request_settings ks on (ks.ddp_instance_id = req.ddp_instance_id AND ks.kit_type_id = req.kit_type_id) " +
+            "LEFT JOIN carrier_service cs on (ks.carrier_service_to_id = cs.carrier_service_id) WHERE req.ddp_instance_id = ? AND kit.scan_date IS NOT NULL AND kit.deactivation_reason IS NULL";
+
+
+    private String ddpKitRequestId;
     private String kitType;
     private String trackingId;
     private String carrier;
@@ -28,6 +36,16 @@ public class KitStatus {
     private Long received;
 
     public KitStatus(String kitType, String trackingId, String carrier, Long sent, Long delivered, Long received) {
+        this.kitType = kitType;
+        this.trackingId = trackingId;
+        this.carrier = carrier;
+        this.sent = sent;
+        this.delivered = delivered;
+        this.received = received;
+    }
+
+    public KitStatus(String ddpKitRequestId, String kitType, String trackingId, String carrier, Long sent, Long delivered, Long received) {
+        this.ddpKitRequestId = ddpKitRequestId;
         this.kitType = kitType;
         this.trackingId = trackingId;
         this.carrier = carrier;
@@ -65,11 +83,49 @@ public class KitStatus {
         });
 
         if (results.resultException != null) {
-            throw new RuntimeException("Error getting list of assignees ", results.resultException);
+            throw new RuntimeException("Error getting list of kit status ", results.resultException);
         }
         if (!kitStatuses.isEmpty()) {
             return kitStatuses;
         }
         return null;
+    }
+
+    public static Map<String, List<KitStatus>> getBatchOfSampleStatus( @NonNull String instanceId) {
+        Map<String, List<KitStatus>> results = new HashMap<>();
+        SimpleResult simpleResult = inTransaction((conn) -> {
+            SimpleResult dbVals = new SimpleResult();
+            try (PreparedStatement stmt = conn.prepareStatement(SQL_SELECT_BATCH_SAMPLES_STATUS)) {
+                stmt.setString(1, instanceId);
+                try (ResultSet rs = stmt.executeQuery()) {
+                    while (rs.next()) {
+                        String ddpParticipantId = rs.getString(DBConstants.DDP_PARTICIPANT_ID);
+                        Object sent = rs.getObject(DBConstants.DSM_SCAN_DATE);
+                        Object delivered = rs.getObject(DBConstants.EASYPOST_SHIPMENT_DATE);
+                        Object received = rs.getObject(DBConstants.DSM_RECEIVE_DATE);
+                        String trackingId = rs.getString(DBConstants.DSM_TRACKING_TO);
+                        List<KitStatus> kitStatuses= results.getOrDefault(ddpParticipantId, new ArrayList<>());
+                        kitStatuses.add(new KitStatus(rs.getString("ddp_kit_request_id"),
+                                rs.getString(DBConstants.KIT_TYPE_NAME),
+                                trackingId,
+                                trackingId != null ? rs.getString(DBConstants.DSM_CARRIER_TO) : null,
+                                sent != null ? (Long) sent / 1000 : null,
+                                delivered != null ? (Long) sent / 1000 : null,
+                                received != null ? (Long) received / 1000 : null
+                                ));
+                        results.put(ddpParticipantId, kitStatuses);
+                    }
+                }
+            }
+            catch (SQLException ex) {
+                dbVals.resultException = ex;
+            }
+            return dbVals;
+        });
+
+        if (simpleResult.resultException != null) {
+            throw new RuntimeException("Error getting list of Kit Statuses for a batch ", simpleResult.resultException);
+        }
+        return results;
     }
 }

--- a/src/main/java/org/broadinstitute/dsm/db/ViewFilter.java
+++ b/src/main/java/org/broadinstitute/dsm/db/ViewFilter.java
@@ -21,6 +21,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
+import java.sql.Statement;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
@@ -206,7 +207,7 @@ public class ViewFilter {
                                      @NonNull String ddpGroupId, @NonNull String columnString) {
         SimpleResult results = inTransaction((conn) -> {
             SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement stmt = conn.prepareStatement(SQL_INSERT_VIEW)) {
+            try (PreparedStatement stmt = conn.prepareStatement(SQL_INSERT_VIEW, Statement.RETURN_GENERATED_KEYS)) {
                 stmt.setString(1, columnString);
                 stmt.setString(2, viewFilter.getFilterName());
                 stmt.setString(3, userId);

--- a/src/main/java/org/broadinstitute/dsm/exception/CareEvolveException.java
+++ b/src/main/java/org/broadinstitute/dsm/exception/CareEvolveException.java
@@ -1,0 +1,16 @@
+package org.broadinstitute.dsm.exception;
+
+/**
+ * Exception thrown when there is an error placing
+ * COVID-19 orders in CareEvolve
+ */
+public class CareEvolveException extends RuntimeException {
+
+    public CareEvolveException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CareEvolveException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/files/PDFProcessor.java
+++ b/src/main/java/org/broadinstitute/dsm/files/PDFProcessor.java
@@ -106,7 +106,7 @@ public abstract class PDFProcessor implements BasicProcessor {
             gcpCreds = TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.GOOGLE_PROJECT_CREDENTIALS);
         }
         String gcpName = TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.GOOGLE_PROJECT_NAME);
-        if (StringUtils.isNotBlank(gcpCreds) && StringUtils.isNotBlank(gcpName)) {
+        if (StringUtils.isNotBlank(gcpName)) {
             String bucketName = TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.GOOGLE_CONFIG_BUCKET);
             try {
                 if (GoogleBucket.bucketExists(gcpCreds, gcpName, bucketName)) {

--- a/src/main/java/org/broadinstitute/dsm/files/PDFProcessor.java
+++ b/src/main/java/org/broadinstitute/dsm/files/PDFProcessor.java
@@ -101,7 +101,10 @@ public abstract class PDFProcessor implements BasicProcessor {
     }
 
     public static byte[] getTemplateFromGoogleBucket(@NonNull String fileName) {
-        String gcpCreds = TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.GOOGLE_PROJECT_CREDENTIALS);
+        String gcpCreds = null;
+        if (TransactionWrapper.hasConfigPath(ApplicationConfigConstants.GOOGLE_PROJECT_CREDENTIALS)) {
+            gcpCreds = TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.GOOGLE_PROJECT_CREDENTIALS);
+        }
         String gcpName = TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.GOOGLE_PROJECT_NAME);
         if (StringUtils.isNotBlank(gcpCreds) && StringUtils.isNotBlank(gcpName)) {
             String bucketName = TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.GOOGLE_CONFIG_BUCKET);

--- a/src/main/java/org/broadinstitute/dsm/jetty/JettyConfig.java
+++ b/src/main/java/org/broadinstitute/dsm/jetty/JettyConfig.java
@@ -1,0 +1,153 @@
+package org.broadinstitute.dsm.jetty;
+
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.session.SessionHandler;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.thread.ThreadPool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import spark.ExceptionMapper;
+import spark.embeddedserver.EmbeddedServer;
+import spark.embeddedserver.EmbeddedServerFactory;
+import spark.embeddedserver.EmbeddedServers;
+import spark.embeddedserver.jetty.EmbeddedJettyServer;
+import spark.embeddedserver.jetty.HttpRequestWrapper;
+import spark.embeddedserver.jetty.JettyServerFactory;
+import spark.http.matching.MatcherFilter;
+import spark.route.Routes;
+import spark.staticfiles.StaticFilesConfiguration;
+
+public class JettyConfig {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JettyConfig.class);
+
+    public static void setupJetty(String preferredSourceIPHeader) {
+        if (StringUtils.isBlank(preferredSourceIPHeader)) {
+            LOG.warn("Source IP will be servlet default.  If you're running behind a load balancer or other device, source IP "
+                    + "may be incorrect.");
+        } else {
+            LOG.warn("Source IP will be taken from header {} if available.", preferredSourceIPHeader);
+        }
+        EmbeddedServers.add(EmbeddedServers.Identifiers.JETTY, new AppEngineServerFactory(new JettyServer(), preferredSourceIPHeader));
+    }
+
+    /**
+     * Lifted from {@link spark.embeddedserver.jetty.EmbeddedJettyFactory} with a change
+     * to use {@link JettyCustomRemoteAddrHeaderHandler} to override {@link HttpServletRequest#getRemoteAddr()}
+     */
+    private static class AppEngineServerFactory implements EmbeddedServerFactory {
+        private final JettyServerFactory serverFactory;
+        private String preferredIPSourceHeader;
+        private ThreadPool threadPool;
+        private boolean httpOnly = true;
+
+        public AppEngineServerFactory(JettyServerFactory serverFactory, String preferredIPSourceHeader) {
+            this.serverFactory = serverFactory;
+            this.preferredIPSourceHeader = preferredIPSourceHeader;
+        }
+
+        public EmbeddedServer create(Routes routeMatcher, StaticFilesConfiguration staticFilesConfiguration,
+                                     ExceptionMapper exceptionMapper, boolean hasMultipleHandler) {
+            MatcherFilter matcherFilter = new MatcherFilter(routeMatcher, staticFilesConfiguration, exceptionMapper, false,
+                    hasMultipleHandler);
+            matcherFilter.init(null);
+            SessionHandler handler = new JettyCustomRemoteAddrHeaderHandler(matcherFilter, this.preferredIPSourceHeader);
+            handler.getSessionCookieConfig().setHttpOnly(this.httpOnly);
+            return (new EmbeddedJettyServer(this.serverFactory, handler)).withThreadPool(this.threadPool);
+        }
+
+        public AppEngineServerFactory withThreadPool(ThreadPool threadPool) {
+            this.threadPool = threadPool;
+            return this;
+        }
+
+        public AppEngineServerFactory withHttpOnly(boolean httpOnly) {
+            this.httpOnly = httpOnly;
+            return this;
+        }
+    }
+
+    /**
+     * Lifted from {@link spark.embeddedserver.jetty.JettyHandler}, with one
+     * change to use {@link SourceIPHeaderRequestWrapper} to set
+     * the source IP properly in the appengine environment
+     */
+    public static class JettyCustomRemoteAddrHeaderHandler extends SessionHandler {
+        private javax.servlet.Filter filter;
+        private String preferredIPSourceHeader;
+
+        public JettyCustomRemoteAddrHeaderHandler(Filter filter, String preferredIPSourceHeader) {
+            this.filter = filter;
+            this.preferredIPSourceHeader = preferredIPSourceHeader;
+        }
+
+        public void doHandle(String target, org.eclipse.jetty.server.Request baseRequest, HttpServletRequest request,
+                             HttpServletResponse response) throws IOException, ServletException {
+            HttpRequestWrapper wrapper = new SourceIPHeaderRequestWrapper(request, preferredIPSourceHeader);
+            this.filter.doFilter(wrapper, response, null);
+            if (wrapper.notConsumed()) {
+                baseRequest.setHandled(false);
+            } else {
+                baseRequest.setHandled(true);
+            }
+        }
+    }
+
+    /**
+     * Lifted from {@link spark.embeddedserver.jetty.JettyServer}
+     */
+    public static class JettyServer implements JettyServerFactory {
+        JettyServer() {
+        }
+
+        public Server create(int maxThreads, int minThreads, int threadTimeoutMillis) {
+            Server server;
+            if (maxThreads > 0) {
+                int min = minThreads > 0 ? minThreads : 8;
+
+                int idleTimeout = threadTimeoutMillis > 0 ? threadTimeoutMillis : 30_000;
+                server = new Server(new QueuedThreadPool(maxThreads, min, idleTimeout));
+            } else {
+                server = new Server();
+            }
+
+            return server;
+        }
+
+        public Server create(ThreadPool threadPool) {
+            return threadPool != null ? new Server(threadPool) : new Server();
+        }
+    }
+
+    /**
+     * RequestWrapper that uses a different header as the preferred source
+     * for the ip address that is returned by {@link HttpServletRequest#getRemoteAddr()}.
+     */
+    public static class SourceIPHeaderRequestWrapper extends HttpRequestWrapper {
+
+        String remoteAddr;
+
+        public SourceIPHeaderRequestWrapper(HttpServletRequest request, String preferredHeaderForIP) {
+            super(request);
+            remoteAddr = request.getRemoteAddr();
+            if (StringUtils.isNotBlank(preferredHeaderForIP)) {
+                String ipFromHeader = request.getHeader(preferredHeaderForIP);
+                if (StringUtils.isNotBlank(ipFromHeader)) {
+                    remoteAddr = ipFromHeader;
+                }
+            }
+        }
+
+        @Override
+        public String getRemoteAddr() {
+            return remoteAddr;
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/model/KitDDPNotification.java
+++ b/src/main/java/org/broadinstitute/dsm/model/KitDDPNotification.java
@@ -49,7 +49,7 @@ public class KitDDPNotification {
     public static KitDDPNotification getKitDDPNotification(@NonNull String query, @NonNull String kitLabel) {
         SimpleResult results = inTransaction((conn) -> {
             SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement stmt = conn.prepareStatement(query)) {
+            try (PreparedStatement stmt = conn.prepareStatement(query,ResultSet.TYPE_SCROLL_SENSITIVE,ResultSet.CONCUR_READ_ONLY)) {
                 stmt.setString(1, kitLabel);
                 try (ResultSet rs = stmt.executeQuery()) {
                     rs.last();

--- a/src/main/java/org/broadinstitute/dsm/model/ParticipantKits.java
+++ b/src/main/java/org/broadinstitute/dsm/model/ParticipantKits.java
@@ -1,0 +1,16 @@
+package org.broadinstitute.dsm.model;
+
+import org.broadinstitute.dsm.db.KitRequestShipping;
+import org.broadinstitute.dsm.db.KitStatus;
+
+import java.util.List;
+
+public class ParticipantKits {
+    String participantId;
+    List<KitStatus> samples;
+
+    public ParticipantKits(String participantId, List<KitStatus> samples) {
+        this.participantId = participantId;
+        this.samples = samples;
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/model/ddp/DDPListOfParticipants.java
+++ b/src/main/java/org/broadinstitute/dsm/model/ddp/DDPListOfParticipants.java
@@ -1,0 +1,5 @@
+package org.broadinstitute.dsm.model.ddp;
+
+public class DDPListOfParticipants {
+    public String[] participantIds;
+}

--- a/src/main/java/org/broadinstitute/dsm/route/AssignParticipantRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/AssignParticipantRoute.java
@@ -211,7 +211,8 @@ public class AssignParticipantRoute extends RequestHandler {
     public String getDDPParticipantId(@NonNull String participantId) {
         SimpleResult results = inTransaction((conn) -> {
             SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement stmt = conn.prepareStatement(queryForDDPParticipantId)) {
+            try (PreparedStatement stmt = conn.prepareStatement(queryForDDPParticipantId,
+                    ResultSet.TYPE_SCROLL_SENSITIVE,ResultSet.CONCUR_READ_ONLY)) {
                 stmt.setString(1, participantId);
                 try (ResultSet rs = stmt.executeQuery()) {
                     rs.last();

--- a/src/main/java/org/broadinstitute/dsm/route/BatchKitsRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/BatchKitsRoute.java
@@ -42,9 +42,10 @@ public class BatchKitsRoute implements Route {
                             results.add(new ParticipantKits(ddpParticipantId, samples));
                         }
                     }
-                    logger.info("Sending a list of " + results.size() + " KitRequestShippings for study " + study);
-                    return results;
+
                 }
+                logger.info("Sending a list of " + results.size() + " kit status for batch of participants for study " + study);
+                return results;
             }
             logger.error("No study found for: " + study);
             response.status(404);

--- a/src/main/java/org/broadinstitute/dsm/route/BatchKitsRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/BatchKitsRoute.java
@@ -1,0 +1,57 @@
+package org.broadinstitute.dsm.route;
+
+import com.google.gson.Gson;
+import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.dsm.db.DDPInstance;
+import org.broadinstitute.dsm.db.KitStatus;
+import org.broadinstitute.dsm.model.ParticipantKits;
+import org.broadinstitute.dsm.model.ddp.DDPListOfParticipants;
+import org.broadinstitute.dsm.statics.RequestParameter;
+import org.broadinstitute.dsm.util.SystemUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import spark.Request;
+import spark.Response;
+import spark.Route;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class BatchKitsRoute implements Route {
+    private static final Logger logger = LoggerFactory.getLogger(BatchKitsRoute.class);
+
+    @Override
+    public Object handle(Request request, Response response) throws Exception {
+        String study = request.params(RequestParameter.REALM);
+        String ids = null;
+        if (StringUtils.isNotBlank(study)) {
+            HttpServletRequest rawRequest = request.raw();
+            String content = SystemUtil.getBody(rawRequest);
+            String[] ddpParticipantIds = new Gson().fromJson(content, DDPListOfParticipants.class).participantIds;
+            DDPInstance ddpInstance = DDPInstance.getDDPInstance(study);
+            List<ParticipantKits> results = new ArrayList<>();
+            if (ddpInstance != null) {
+                if (ddpParticipantIds != null && ddpParticipantIds.length != 0) {
+                    Map<String, List<KitStatus>> kitRequests = KitStatus.getBatchOfSampleStatus(ddpInstance.getDdpInstanceId());
+
+                    for (String ddpParticipantId : ddpParticipantIds) {
+                        if (kitRequests.containsKey(ddpParticipantId)) {
+                            List<KitStatus> samples = kitRequests.get(ddpParticipantId);
+                            results.add(new ParticipantKits(ddpParticipantId, samples));
+                        }
+                    }
+                    logger.info("Sending a list of " + results.size() + " KitRequestShippings for study " + study);
+                    return results;
+                }
+            }
+            logger.error("No study found for: " + study);
+            response.status(404);
+            return results;
+        }
+        logger.error("No value was sent for realm");
+        response.status(500);
+        return new ArrayList<>();
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/route/DashboardRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/DashboardRoute.java
@@ -137,7 +137,7 @@ public class DashboardRoute extends RequestHandler {
                                          @NonNull String returnColumn) {
         SimpleResult results = inTransaction((conn) -> {
             SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement stmt = conn.prepareStatement(query)) {
+            try (PreparedStatement stmt = conn.prepareStatement(query,ResultSet.TYPE_SCROLL_SENSITIVE,ResultSet.CONCUR_READ_ONLY)) {
                 stmt.setString(1, realm);
                 stmt.setInt(2, kitType.getKitId());
                 try (ResultSet rs = stmt.executeQuery()) {
@@ -615,7 +615,8 @@ public class DashboardRoute extends RequestHandler {
                                                    @NonNull KitType kitType) {
         SimpleResult results = inTransaction((conn) -> {
             SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement stmt = conn.prepareStatement(TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.GET_DASHBOARD_INFORMATION_OF_KIT_REQUESTS))) {
+            try (PreparedStatement stmt = conn.prepareStatement(TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.GET_DASHBOARD_INFORMATION_OF_KIT_REQUESTS),
+                    ResultSet.TYPE_SCROLL_SENSITIVE,ResultSet.CONCUR_READ_ONLY)) {
                 stmt.setString(1, realm);
                 stmt.setInt(2, kitType.getKitId());
                 stmt.setString(3, realm);

--- a/src/main/java/org/broadinstitute/dsm/route/DownloadPDFRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/DownloadPDFRoute.java
@@ -215,7 +215,7 @@ public class DownloadPDFRoute extends RequestHandler {
 
             if (ddpInstance != null && StringUtils.isNotBlank(ddpParticipantId)) {
                 if (COVER_PDF.equals(pdfType)) {
-                    logger.info("Generating cover pdf");
+                    logger.info("Generating cover pdf for onc history {}", StringUtils.join(oncHistoryIDs,","));
                     JSONObject jsonObject = new JSONObject(requestBody);
                     Set keySet = jsonObject.keySet();
                     String startDate = null;
@@ -296,7 +296,7 @@ public class DownloadPDFRoute extends RequestHandler {
                     }
                 }
                 else if (REQUEST_PDF.equals(pdfType)) {
-                    logger.info("Generating request pdf");
+                    logger.info("Generating request pdf for onc history ids {}", StringUtils.join(oncHistoryIDs, ","));
                     RequestPDFProcessor processor = new RequestPDFProcessor(ddpInstance.getName());
                     Map<String, Object> valueMap = new HashMap<>();
                     String today = new SimpleDateFormat("MM/dd/yyyy").format(new Date());
@@ -314,18 +314,20 @@ public class DownloadPDFRoute extends RequestHandler {
                     InputStream stream = null;
                     try {
                         int counter = 0;
-                        for (int i = 0; i < oncHistoryIDs.size(); i++) {
-                            OncHistoryDetail oncHistoryDetail = OncHistoryDetail.getOncHistoryDetail(oncHistoryIDs.get(i), realm);
-                            // facility information is the same in all of the requests so only need to be set ones!
-                            if (i == 0) {
-                                valueMap.put(RequestPDFProcessor.FIELD_CONFIRMED_INSTITUTION_NAME, oncHistoryDetail.getFacility());
-                                valueMap.put(RequestPDFProcessor.FIELD_CONFIRMED_PHONE, oncHistoryDetail.getFPhone());
-                                valueMap.put(RequestPDFProcessor.FIELD_CONFIRMED_FAX, oncHistoryDetail.getFFax());
+                        if (oncHistoryIDs != null) {
+                            for (int i = 0; i < oncHistoryIDs.size(); i++) {
+                                OncHistoryDetail oncHistoryDetail = OncHistoryDetail.getOncHistoryDetail(oncHistoryIDs.get(i), realm);
+                                // facility information is the same in all of the requests so only need to be set ones!
+                                if (i == 0) {
+                                    valueMap.put(RequestPDFProcessor.FIELD_CONFIRMED_INSTITUTION_NAME, oncHistoryDetail.getFacility());
+                                    valueMap.put(RequestPDFProcessor.FIELD_CONFIRMED_PHONE, oncHistoryDetail.getFPhone());
+                                    valueMap.put(RequestPDFProcessor.FIELD_CONFIRMED_FAX, oncHistoryDetail.getFFax());
+                                }
+                                valueMap.put(RequestPDFProcessor.FIELD_DATE_PX + i, oncHistoryDetail.getDatePX());
+                                valueMap.put(RequestPDFProcessor.FIELD_TYPE_LOCATION + i, oncHistoryDetail.getTypePX());
+                                valueMap.put(RequestPDFProcessor.FIELD_ACCESSION_NUMBER + i, oncHistoryDetail.getAccessionNumber());
+                                counter = i;
                             }
-                            valueMap.put(RequestPDFProcessor.FIELD_DATE_PX + i, oncHistoryDetail.getDatePX());
-                            valueMap.put(RequestPDFProcessor.FIELD_TYPE_LOCATION + i, oncHistoryDetail.getTypePX());
-                            valueMap.put(RequestPDFProcessor.FIELD_ACCESSION_NUMBER + i, oncHistoryDetail.getAccessionNumber());
-                            counter = i;
                         }
                         valueMap.put(RequestPDFProcessor.BLOCK_COUNTER, counter + 1);
 

--- a/src/main/java/org/broadinstitute/dsm/route/LoggingFilter.java
+++ b/src/main/java/org/broadinstitute/dsm/route/LoggingFilter.java
@@ -44,8 +44,8 @@ public class LoggingFilter implements Filter {
                     }
                 }
 
-            } catch (Exception e) {
-                logger.error("Could not decode token", e);
+            } catch (JWTDecodeException e) {
+                logger.debug("Could not decode token", e);
             }
         }
 

--- a/src/main/java/org/broadinstitute/dsm/route/LoggingFilter.java
+++ b/src/main/java/org/broadinstitute/dsm/route/LoggingFilter.java
@@ -1,0 +1,58 @@
+package org.broadinstitute.dsm.route;
+
+import java.util.Map;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.auth0.jwt.impl.JWTParser;
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.ddp.util.Utility;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.log4j.MDC;
+import spark.Filter;
+import spark.Request;
+import spark.Response;
+
+/**
+ * Captures client IP and name of user from token, adding
+ * them to MDC for logging.
+ */
+public class LoggingFilter implements Filter {
+
+    public static final String CLIENT_IP = "CLIENT_IP";
+
+    public static final String USER_EMAIL = "USER_EMAIL";
+
+    private static final Logger logger = LoggerFactory.getLogger(LoggingFilter.class);
+
+    @Override
+    public void handle(Request request, Response response) {
+        String tokenFromHeader = Utility.getTokenFromHeader(request);
+        if (StringUtils.isNotBlank(tokenFromHeader)) {
+            try  {
+                DecodedJWT decodedUnverifiedJWT = JWT.decode(tokenFromHeader);
+                Claim userEmailClaim = decodedUnverifiedJWT.getClaim("USER_MAIL");
+
+                if (userEmailClaim != null) {
+                    String userEmail = userEmailClaim.asString();
+                    if (StringUtils.isNotBlank(userEmail)) {
+                        MDC.put(USER_EMAIL, userEmail);
+                    }
+                }
+
+            } catch (Exception e) {
+                logger.error("Could not decode token", e);
+            }
+        }
+
+        // set the ip  so that log4j can include it
+        if (StringUtils.isNotBlank(request.ip())) {
+            MDC.put(CLIENT_IP, request.ip());
+        }
+        logger.info("Accessing " + request.url());
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/statics/ApplicationConfigConstants.java
+++ b/src/main/java/org/broadinstitute/dsm/statics/ApplicationConfigConstants.java
@@ -121,4 +121,6 @@ public class ApplicationConfigConstants {
     public static final String GET_ALL_HOSPITALS_MBC = "mbc.selectAllHospitals";
     public static final String GET_PARTICIPANTS_MBC = "mbc.selectParticipants";
 
+    public static final String PREFERRED_SOURCE_IP_HEADER = "preferredSourceIPHeader";
+
 }

--- a/src/main/java/org/broadinstitute/dsm/statics/ApplicationConfigConstants.java
+++ b/src/main/java/org/broadinstitute/dsm/statics/ApplicationConfigConstants.java
@@ -124,4 +124,5 @@ public class ApplicationConfigConstants {
     public static final String PREFERRED_SOURCE_IP_HEADER = "preferredSourceIPHeader";
     public static final String BOOT_TIMEOUT = "bootTimeout";
 
+    public static final String CORS_ALLOWED_ORIGINS = "corsOrigins";
 }

--- a/src/main/java/org/broadinstitute/dsm/statics/ApplicationConfigConstants.java
+++ b/src/main/java/org/broadinstitute/dsm/statics/ApplicationConfigConstants.java
@@ -125,4 +125,12 @@ public class ApplicationConfigConstants {
     public static final String BOOT_TIMEOUT = "bootTimeout";
 
     public static final String CORS_ALLOWED_ORIGINS = "corsOrigins";
+
+    public static final String CARE_EVOLVE_ACCOUNT ="careEvolve.account";
+
+    public static final String CARE_EVOLVE_SUBSCRIBER_KEY = "careEvolve.subscriberKey";
+
+    public static final String CARE_EVOLVE_SERVICE_KEY = "careEvolve.serviceKey";
+
+    public static final String CARE_EVOLVE_ORDER_ENDPOINT = "careEvolve.orderEndpoint";
 }

--- a/src/main/java/org/broadinstitute/dsm/statics/ApplicationConfigConstants.java
+++ b/src/main/java/org/broadinstitute/dsm/statics/ApplicationConfigConstants.java
@@ -122,5 +122,6 @@ public class ApplicationConfigConstants {
     public static final String GET_PARTICIPANTS_MBC = "mbc.selectParticipants";
 
     public static final String PREFERRED_SOURCE_IP_HEADER = "preferredSourceIPHeader";
+    public static final String BOOT_TIMEOUT = "bootTimeout";
 
 }

--- a/src/main/java/org/broadinstitute/dsm/statics/RoutePath.java
+++ b/src/main/java/org/broadinstitute/dsm/statics/RoutePath.java
@@ -37,6 +37,8 @@ public class RoutePath {
 
     public static final String PARTICIPANT_STATUS_REQUEST = "/participantstatus/" + RequestParameter.REALM + "/" + RequestParameter.PARTICIPANTID;
 
+    public static final String BATCH_KITS_REQUEST = "/batchKitsStatus/" + RequestParameter.REALM ;
+
     public static final String ROUTE_SEPARATOR = "/";
 
     //DSM UI - routes

--- a/src/main/java/org/broadinstitute/dsm/util/DBUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/DBUtil.java
@@ -37,7 +37,7 @@ public class DBUtil {
 
     public static Long getBookmark(Connection conn, String bookmarkName) {
         if (conn != null) {
-            try (PreparedStatement stmt = conn.prepareStatement(SQL_SELECT_BOOKMARK)) {
+            try (PreparedStatement stmt = conn.prepareStatement(SQL_SELECT_BOOKMARK,ResultSet.TYPE_SCROLL_SENSITIVE,ResultSet.CONCUR_READ_ONLY)) {
                 stmt.setString(1, bookmarkName);
                 try (ResultSet rs = stmt.executeQuery()) {
                     rs.last();

--- a/src/main/java/org/broadinstitute/dsm/util/SecurityUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/SecurityUtil.java
@@ -59,7 +59,7 @@ public class SecurityUtil {
             long invalidAfter = 300 + (System.currentTimeMillis() / 1000);
             Map<String, String> claims = new HashMap<>();
             claims.put(CLAIM_ISSUER, SIGNER);
-            token = new SecurityHelper().createToken(secret, invalidAfter, claims);
+            token = SecurityHelper.createToken(secret, invalidAfter, claims);
         }
         if (StringUtils.isBlank(token)) {
             throw new RuntimeException("No token available for " + instanceName);

--- a/src/main/resources/log4j.xml
+++ b/src/main/resources/log4j.xml
@@ -3,7 +3,7 @@
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
     <appender name="console" class="org.apache.log4j.ConsoleAppender">
         <layout class="org.apache.log4j.PatternLayout">
-            <param name="ConversionPattern" value="%d{ISO8601} %-5p [%t] (%C.%M:%L) - %m%n"/>
+            <param name="ConversionPattern" value="%d{ISO8601} %-5p C:%X{CLIENT_IP} U:%X{USER_EMAIL} [%t] (%C.%M:%L) - %m%n"/>
         </layout>
     </appender>
     <appender name="file" class="org.apache.log4j.RollingFileAppender">
@@ -11,7 +11,7 @@
         <param name="MaxFileSize" value="100MB"/>
         <param name="MaxBackupIndex" value="10"/>
         <layout class="org.apache.log4j.PatternLayout">
-            <param name="ConversionPattern" value="%d{ISO8601} %-5p [%t] (%C.%M:%L) - %m%n"/>
+            <param name="ConversionPattern" value="%d{ISO8601} %-5p %X{CLIENT_IP} [%t] (%C.%M:%L) - %m%n"/>
         </layout>
     </appender>
     <appender name="errorNotification" class="org.broadinstitute.ddp.loggers.ErrorNotificationAppender">

--- a/src/main/resources/log4j.xml
+++ b/src/main/resources/log4j.xml
@@ -19,7 +19,6 @@
     <root>
         <priority value ="info" />
         <appender-ref ref="console" />
-        <appender-ref ref="file" />
         <appender-ref ref="errorNotification" />
     </root>
 </log4j:configuration>

--- a/src/test/java/org/broadinstitute/dsm/RouteInfoTest.java
+++ b/src/test/java/org/broadinstitute/dsm/RouteInfoTest.java
@@ -95,8 +95,28 @@ public class RouteInfoTest extends TestHelper {
     }
 
     @Test
+    public void allKitsTestEmptyParticipantList() throws Exception {
+        HttpResponse response = TestUtil.perform(Request.Post(DSM_BASE_URL + "/app/batchKitsStatus/TESTSTUDY1"), "", testUtil.buildAuthHeaders()).returnResponse();
+        Assert.assertEquals(500, response.getStatusLine().getStatusCode());
+    }
+
+    @Test
+    public void allKitsTest() throws Exception {
+        DBTestUtil.createTestData(TEST_DDP, "TEST_PARTICIPANT_1", "TEST_INSTITUTION");
+        DBTestUtil.createTestData(TEST_DDP, "TEST_PARTICIPANT_2", "TEST_INSTITUTION");
+        DBTestUtil.createTestData(TEST_DDP, "TEST_PARTICIPANT_3", "TEST_INSTITUTION");
+
+        String json = "{" +
+                "\"participantIds\":[\"-2104929193.692d24f5-c0eb-4155-865f-2b2fb9ba99fd\", \"-2104929193.692d24f5-c0eb-4155-865f-2b2fb9ba99fd\",\"-2104929193.692d24f5-c0eb-4155-865f-2b2fb9ba99fd\"]" +
+                "}";
+
+        HttpResponse response = TestUtil.perform(Request.Post(DSM_BASE_URL + "/app/batchKitsStatus/GEC"), json, testUtil.buildAuthHeaders()).returnResponse();
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+    }
+
+    @Test
     public void participantStatusParticipantNotFound() throws Exception {
-        HttpResponse response = TestUtil.performGet(DSM_BASE_URL, "/info/" + "participantstatus/TESTSTUDY1/123", getHeaderAppRoute()).returnResponse();
+        HttpResponse response = TestUtil.performGet(DSM_BASE_URL, "/app/" + "participantstatus/TESTSTUDY1/123", getHeaderAppRoute()).returnResponse();
         Assert.assertEquals(200, response.getStatusLine().getStatusCode());
         String message = DDPRequestUtil.getContentAsString(response);
         Gson gson = new GsonBuilder().create();

--- a/src/test/java/org/broadinstitute/dsm/TestHelper.java
+++ b/src/test/java/org/broadinstitute/dsm/TestHelper.java
@@ -87,7 +87,6 @@ public class TestHelper {
     }
 
     public static void setupDB(boolean setupDDPConfigLookup) {
-        cfg = ConfigFactory.load();
         //secrets from vault in a config file
         cfg = cfg.withFallback(ConfigFactory.parseFile(new File("config/test-config.conf")));
 

--- a/src/test/java/org/broadinstitute/dsm/careevolve/Covid19OrderRegistrarTest.java
+++ b/src/test/java/org/broadinstitute/dsm/careevolve/Covid19OrderRegistrarTest.java
@@ -1,0 +1,63 @@
+package org.broadinstitute.dsm.careevolve;
+
+import java.io.File;
+import java.util.List;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.dsm.statics.ApplicationConfigConstants;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class Covid19OrderRegistrarTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(Covid19OrderRegistrarTest.class);
+
+    private static Config cfg;
+
+    @BeforeClass
+    public static void beforeClass() {
+        cfg = ConfigFactory.load().withFallback(ConfigFactory.parseFile(new File("config/ellkay.conf")));
+    }
+
+    @Test
+    public void testSendCareEvoloveOrder() throws Exception {
+        String careEvolveAccount = cfg.getString(ApplicationConfigConstants.CARE_EVOLVE_ACCOUNT);
+        String careEvolveSubscriberKey = cfg.getString(ApplicationConfigConstants.CARE_EVOLVE_SUBSCRIBER_KEY);
+        String careEvolveServiceKey = cfg.getString(ApplicationConfigConstants.CARE_EVOLVE_SERVICE_KEY);
+        String careEvolveOrderEndpoint = cfg.getString(ApplicationConfigConstants.CARE_EVOLVE_ORDER_ENDPOINT);
+        Authentication auth = new Authentication(careEvolveSubscriberKey, careEvolveServiceKey);
+
+        Covid19OrderRegistrar orderRegistrar = new Covid19OrderRegistrar(careEvolveOrderEndpoint);
+
+        Provider provider = new Provider("Lisa", "Cosimi", "1154436111");
+        String pepperUserGuid = "1234";
+        String pepperKitGuid =  "789";
+
+        List<AOE> aoes = AOE.forTestBoston(pepperUserGuid, pepperKitGuid);
+        Address address = new Address("75 Ames St.",null,"Cambridge","MA","02421");
+        Patient testPatient = new Patient("123","foo","bar","1901-01-01","Other","Other",
+                "other",address);
+
+        Message message = new Message(new Order(careEvolveAccount, testPatient, provider, aoes), "GBF2929101");
+
+        OrderResponse orderResponse = orderRegistrar.orderTest(auth, message);
+        Gson gson = new GsonBuilder().serializeNulls().setPrettyPrinting().create();
+
+        logger.info("Order returned " + gson.toJson(orderResponse));
+
+        Assert.assertNotNull(orderResponse);
+        Assert.assertNull(orderResponse.getError());
+        Assert.assertTrue(StringUtils.isNotBlank(orderResponse.getHandle()));
+
+
+    }
+}

--- a/src/test/java/org/broadinstitute/dsm/util/tools/util/DBUtil.java
+++ b/src/test/java/org/broadinstitute/dsm/util/tools/util/DBUtil.java
@@ -49,7 +49,7 @@ public class DBUtil {
     }
 
     public static String checkNotReceived(Connection conn, String selectQuery, Object kitInfo, String returnColumn) throws Exception {
-        try (PreparedStatement stmt = conn.prepareStatement(selectQuery)) {
+        try (PreparedStatement stmt = conn.prepareStatement(selectQuery,ResultSet.TYPE_SCROLL_SENSITIVE,ResultSet.CONCUR_READ_ONLY)) {
             stmt.setObject(1, kitInfo);
             try (ResultSet rs = stmt.executeQuery()) {
                 rs.last();


### PR DESCRIPTION
DDP-4815 is about setting up a utility method for placing orders in CareEvolve for COVID-19.  `Covid19OrderRegistrar` is where most of the action is for this PR--just read the auth settings from SM, create a new `Order`, wrap it in a `Message`, and off it goes to CareEvolve.