### PR TITLE
DDP-4848 enable login via SAML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.broadinstitute.ddp</groupId>
             <artifactId>ldd-backend</artifactId>
-            <version>dsm_2.4_20200717</version>
+            <version>dsm_2.4_20200810</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/broadinstitute/dsm/util/UserUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/UserUtil.java
@@ -18,6 +18,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.*;
 
 import static org.broadinstitute.ddp.db.TransactionWrapper.inTransaction;
@@ -113,7 +114,7 @@ public class UserUtil {
     public void insertUser(@NonNull String name, @NonNull String email) {
         SimpleResult results = inTransaction((conn) -> {
             SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement insertStmt = conn.prepareStatement(SQL_INSERT_USER)) {
+            try (PreparedStatement insertStmt = conn.prepareStatement(SQL_INSERT_USER, Statement.RETURN_GENERATED_KEYS)) {
                 insertStmt.setString(1, name);
                 insertStmt.setString(2, email);
                 insertStmt.executeUpdate();


### PR DESCRIPTION
Use the new jar `dsm_2.4_20200810` which has the fix to help enable login via SAML. Using this, I was able to login locally using a dummy SAML I setup (`okta-dev`), and get a "dsm token" that looks like this:

```
{
  "USER_SETTINGS": "{\"rowsOnPage\":0,\"rowSet0\":0,\"rowSet1\":0,\"rowSet2\":0}",
  "USER_ACCESS_ROLE": "[]",
  "iss": "org.broadinstitute.kdux",
  "USER_ID": "4",
  "USER_NAME": "yufeng+okta.1@broad.dev",
  "exp": 1597297000,
  "USER_MAIL": "yufeng+okta.1@broad.dev"
}
```

NOTE: we'll need to add the SAML connection name to `vault.conf` under the key `auth0.connections` when this change gets deployed.