### PR TITLE
DDP-4900 use a proxy for elasticsearch client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ appengine/deploy/lib
 appengine/deploy/*.conf
 appengine/deploy/tcell/*
 
+# This file is rendered.
+appengine/deploy/StudyManager.yaml
+
 # IDEs and editors
 .idea
 target

--- a/appengine/deploy/StudyManager.tmpl.yaml
+++ b/appengine/deploy/StudyManager.tmpl.yaml
@@ -5,6 +5,9 @@ instance_class: B4
 manual_scaling:
   instances: 1
 
+vpc_access_connector:
+  name: "projects/{{project_id}}/locations/us-central1/connectors/appengine-default-connect"
+
 network:
   instance_tag: study-manager
 

--- a/src/main/java/org/broadinstitute/dsm/statics/ApplicationConfigConstants.java
+++ b/src/main/java/org/broadinstitute/dsm/statics/ApplicationConfigConstants.java
@@ -32,6 +32,7 @@ public class ApplicationConfigConstants {
     public static final String ES_URL = "elasticSearch.url";
     public static final String ES_USERNAME = "elasticSearch.username";
     public static final String ES_PASSWORD = "elasticSearch.password";
+    public static final String ES_PROXY = "elasticSearch.proxy";
 
     //security information
     public static final String BSP_SECRET = "bsp.secret";


### PR DESCRIPTION
See DDP-4900.

This PR adds an optional proxy to use for Elasticsearch. If it's present in the config file, we'll use it. Before deploying this change, we'll need to update `study-manager-config` secret in Secret Manager, for the environments that needs it.