### PR TITLE
DDP-5109 CareEvolve Robustness

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -111,6 +111,8 @@ public class DSMServer extends BasicServer {
     public static String careEvolveSubscriberKey;
     public static String careEvolveServiceKey;
     public static String careEvolveOrderEndpoint;
+    public static int careEvolveMaxRetries;
+    public static int careEvolveRetyWaitSeconds;
     public static String careEvolveAccount;
     public static Authentication careEvolveAuth;
     public static Provider provider;
@@ -586,6 +588,17 @@ public class DSMServer extends BasicServer {
                 careEvolveSubscriberKey = cfg.getString(ApplicationConfigConstants.CARE_EVOLVE_SUBSCRIBER_KEY);
                 careEvolveServiceKey = cfg.getString(ApplicationConfigConstants.CARE_EVOLVE_SERVICE_KEY);
                 careEvolveOrderEndpoint = cfg.getString(ApplicationConfigConstants.CARE_EVOLVE_ORDER_ENDPOINT);
+                if (cfg.hasPath(ApplicationConfigConstants.CARE_EVOLVE_MAX_RETRIES)) {
+                    careEvolveMaxRetries = cfg.getInt(ApplicationConfigConstants.CARE_EVOLVE_MAX_RETRIES);
+                } else {
+                    careEvolveMaxRetries = 5;
+                }
+                if (cfg.hasPath(ApplicationConfigConstants.CARE_EVOLVE_RETRY_WAIT_SECONDS)) {
+                    careEvolveRetyWaitSeconds = cfg.getInt(ApplicationConfigConstants.CARE_EVOLVE_RETRY_WAIT_SECONDS);
+                } else {
+                    careEvolveRetyWaitSeconds = 10;
+                }
+                logger.info("Will retry CareEvolve at most {} times after {} seconds", careEvolveMaxRetries, careEvolveRetyWaitSeconds);
                 provider = new Provider(cfg.getString(ApplicationConfigConstants.CARE_EVOLVE_PROVIDER_FIRSTNAME),
                         cfg.getString(ApplicationConfigConstants.CARE_EVOLVE_PROVIDER_LAST_NAME),
                         cfg.getString(ApplicationConfigConstants.CARE_EVOLVE_PROVIDER_NPI));

--- a/src/main/java/org/broadinstitute/dsm/jobs/UPSTrackingJob.java
+++ b/src/main/java/org/broadinstitute/dsm/jobs/UPSTrackingJob.java
@@ -64,7 +64,8 @@ public class UPSTrackingJob implements Job {
                 if (ddpInstance.isHasRole()) {
                     logger.info("tracking ups ids for " + ddpInstance.getName());
                     Map<String, Map<String, DdpKit>> ids = getResultSet(ddpInstance.getDdpInstanceId());
-                    orderRegistrar = new Covid19OrderRegistrar(DSMServer.careEvolveOrderEndpoint, DSMServer.careEvolveAccount, DSMServer.provider);
+                    orderRegistrar = new Covid19OrderRegistrar(DSMServer.careEvolveOrderEndpoint, DSMServer.careEvolveAccount, DSMServer.provider,
+                            DSMServer.careEvolveMaxRetries, DSMServer.careEvolveRetyWaitSeconds);
                     if (ids != null) {
                         Map<String, DdpKit> kits = ids.get("shipping");
                         if (kits != null) {

--- a/src/main/java/org/broadinstitute/dsm/statics/ApplicationConfigConstants.java
+++ b/src/main/java/org/broadinstitute/dsm/statics/ApplicationConfigConstants.java
@@ -135,4 +135,6 @@ public class ApplicationConfigConstants {
     public static final String CARE_EVOLVE_PROVIDER_FIRSTNAME = "careEvolve.provider.firstName";
     public static final String CARE_EVOLVE_PROVIDER_LAST_NAME = "careEvolve.provider.lastName";
     public static final String CARE_EVOLVE_PROVIDER_NPI = "careEvolve.provider.NPI";
+    public static final String CARE_EVOLVE_MAX_RETRIES = "careEvolve.maxRetries";
+    public static final String CARE_EVOLVE_RETRY_WAIT_SECONDS = "careEvolve.retryWaitSeconds";
 }

--- a/src/test/java/org/broadinstitute/dsm/careevolve/Covid19OrderRegistrarTest.java
+++ b/src/test/java/org/broadinstitute/dsm/careevolve/Covid19OrderRegistrarTest.java
@@ -51,7 +51,7 @@ public class Covid19OrderRegistrarTest {
     @Ignore
     @Test
     public void testOrderForParticipant() throws Exception {
-        Covid19OrderRegistrar orderRegistrar = new Covid19OrderRegistrar(careEvolveOrderEndpoint, careEvolveAccount, provider);
+        Covid19OrderRegistrar orderRegistrar = new Covid19OrderRegistrar(careEvolveOrderEndpoint, careEvolveAccount, provider, 0, 0);
 
         orderRegistrar.orderTest(auth,"PUTPKX","TBOS-112211221","kit130", Instant.now());
 


### PR DESCRIPTION
DDP-5109 wraps CE ordering in a loop with `Thread.sleep()` so that if there's an issue with CE, we retry a few times before giving up.

Config file changes will need to be applied to dev and prod secret manager for `careEvolve.maxRetries` and `careEvolve.retryWaitSeconds`.  Suggest we do 3 attempts with a 5s pause between each.