### PR TITLE
DDP-5389 do not restrict updates when kit_complete = 1 for GBF

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/model/KitRequestExternal.java
+++ b/src/main/java/org/broadinstitute/dsm/model/KitRequestExternal.java
@@ -17,7 +17,7 @@ public class KitRequestExternal extends KitRequest {
             "WHERE dsm_kit_request_id = (SELECT request.dsm_kit_request_id FROM ddp_kit_request request LEFT JOIN (SELECT * from (SELECT kit.dsm_kit_request_id, kit.kit_complete " +
             "FROM ddp_kit kit INNER JOIN(SELECT dsm_kit_request_id, MAX(dsm_kit_id) AS kit_id FROM ddp_kit GROUP BY dsm_kit_request_id) groupedKit " +
             "ON kit.dsm_kit_request_id = groupedKit.dsm_kit_request_id AND kit.dsm_kit_id = groupedKit.kit_id)as wtf) as kit ON kit.dsm_kit_request_id = request.dsm_kit_request_id " +
-            "WHERE request.dsm_kit_request_id = ? and not kit.kit_complete <=> 1 limit 1)";
+            "WHERE request.dsm_kit_request_id = ? limit 1)";
     private static final String SQL_UPDATE_KIT_REQUEST_EXTERNAL_SHIPPER_STATUS = "UPDATE ddp_kit_request SET external_order_status = ?, external_order_date = ? WHERE dsm_kit_request_id = ? AND NOT external_order_status <=> ?";
     private static final String SQL_UPDATE_KIT_REQUEST_EXTERNAL_SHIPPER_RESPONSE = "UPDATE ddp_kit_request SET external_response = ? WHERE dsm_kit_request_id = ?";
 

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
@@ -303,7 +303,7 @@ public class GBFRequestUtil implements ExternalShipper {
                                 }
                             }
                             else {
-                                logger.info("No kit requests found for kit with order number: " + confirmation.getOrderNumber());
+                                logger.error("No kit requests found for kit with order number: " + confirmation.getOrderNumber());
                             }
                         } else {
                             logger.error("No items for order " + confirmation.getOrderNumber());

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
@@ -299,7 +299,7 @@ public class GBFRequestUtil implements ExternalShipper {
                                             kitLabel, SystemUtil.getLongFromDateString(confirmation.getShipDate()), EXTERNAL_SHIPPER_NAME,
                                             kitRequest.getDsmKitRequestId());
                                     counter++;
-                                    logger.info("Updated confirmation information for : " + kitRequest.getDsmKitRequestId());
+                                    logger.info("Updated confirmation information for : " + kitRequest.getDsmKitRequestId() + " " + kitLabel);
                                 }
                             }
                             else {

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
@@ -299,11 +299,11 @@ public class GBFRequestUtil implements ExternalShipper {
                                             kitLabel, SystemUtil.getLongFromDateString(confirmation.getShipDate()), EXTERNAL_SHIPPER_NAME,
                                             kitRequest.getDsmKitRequestId());
                                     counter++;
-                                    logger.info("Updated confirmation information for : " + kitRequest.getDsmKitRequestId() + " " + kitLabel);
+                                    logger.info("Updated confirmation information for : " + kitRequest.getDsmKitRequestId());
                                 }
                             }
                             else {
-                                logger.error("No kit requests found for kit with order number: " + confirmation.getOrderNumber());
+                                logger.info("No kit requests found for kit with order number: " + confirmation.getOrderNumber());
                             }
                         } else {
                             logger.error("No items for order " + confirmation.getOrderNumber());


### PR DESCRIPTION
DDP-5389.  Because GBF sometimes updates kit details for the same kit over time, we will refresh our kit data each time we read data from GBF, and assume that kit metadata may change at any time.