### PR TITLE
DDP-5479 Stream GBF Updates

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
+++ b/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
@@ -42,12 +42,11 @@ public class KitRequestShipping extends KitRequest {
             "request.kit_type_id, request.external_order_status, request.external_order_number, request.external_order_date, request.external_response, request.upload_reason, kt.no_return, request.created_by, " +
             "kit.dsm_kit_request_id, kit.dsm_kit_id, kit.kit_complete, kit.label_url_to, kit.label_url_return, kit.tracking_to_id, " +
             "kit.tracking_return_id, kit.easypost_tracking_to_url, kit.easypost_tracking_return_url, kit.easypost_to_id, kit.easypost_shipment_status, kit.scan_date, kit.label_date, kit.error, kit.message, " +
-            "kit.receive_date, kit.deactivated_date, kit.easypost_address_id_to, kit.deactivation_reason, tracking.tracking_id, kit.kit_label, kit.express, kit.test_result, kit.needs_approval, kit.authorization, kit.denial_reason, " +
+            "kit.receive_date, kit.deactivated_date, kit.easypost_address_id_to, kit.deactivation_reason, (select t.tracking_id from ddp_kit_tracking t where t.kit_label = kit.kit_label) as tracking_id, kit.kit_label, kit.express, kit.test_result, kit.needs_approval, kit.authorization, kit.denial_reason, " +
             "kit.authorized_by, kit.ups_tracking_status, kit.ups_return_status, kit.CE_order " +
             "FROM ddp_kit_request request " +
             "LEFT JOIN ddp_kit kit on (kit.dsm_kit_request_id = request.dsm_kit_request_id) " +
             "LEFT JOIN ddp_instance realm on (realm.ddp_instance_id = request.ddp_instance_id) " +
-            "LEFT JOIN ddp_kit_tracking tracking ON (kit.kit_label = tracking.kit_label) " +
             "LEFT JOIN kit_type kt on (request.kit_type_id = kt.kit_type_id) ";
     public static final String SQL_SELECT_KIT_REQUEST = "SELECT * FROM ( SELECT req.upload_reason, kt.kit_type_name, ddp_site.instance_name, ddp_site.ddp_instance_id, ddp_site.base_url, ddp_site.auth0_token, ddp_site.billing_reference, " +
             "ddp_site.migrated_ddp, ddp_site.collaborator_id_prefix, ddp_site.es_participant_index, req.bsp_collaborator_participant_id, req.bsp_collaborator_sample_id, req.ddp_participant_id, req.ddp_label, req.dsm_kit_request_id, " +

--- a/src/main/java/org/broadinstitute/dsm/jobs/ExternalShipperJob.java
+++ b/src/main/java/org/broadinstitute/dsm/jobs/ExternalShipperJob.java
@@ -25,9 +25,7 @@ public class ExternalShipperJob implements Job {
             try {
                 logger.info("Starting the external shipper job");
                 ExternalShipper shipper = (ExternalShipper) Class.forName(DSMServer.getClassName(kitType.getExternalShipper())).newInstance();//GBFRequestUtil
-                ArrayList<KitRequest> kitRequests = shipper.getKitRequestsNotDone(kitType.getInstanceId());
-                shipper.orderStatus(kitRequests);
-                kitRequests.clear();
+                shipper.updateOrderStatusForPendingKitRequests(kitType.getInstanceId());
                 Instant now = Instant.now();
                 Instant dynamicStartTime = now.minus(5, ChronoUnit.DAYS);
                 shipper.orderConfirmation(dynamicStartTime.toEpochMilli(), now.toEpochMilli());

--- a/src/main/java/org/broadinstitute/dsm/jobs/TestBostonUPSTrackingJob.java
+++ b/src/main/java/org/broadinstitute/dsm/jobs/TestBostonUPSTrackingJob.java
@@ -181,8 +181,7 @@ public class TestBostonUPSTrackingJob implements Job {
                                            DdpKit kit,
                                            Instant earliestInTransitTime) {
         String upsUpdate = statusType + " " + statusDescription;
-        SimpleResult result = inTransaction((conn) -> {
-            SimpleResult dbVals = new SimpleResult();
+        inTransaction((conn) -> {
             try (PreparedStatement stmt = conn.prepareStatement(query)) {
                 stmt.setString(1, upsUpdate);
                 stmt.setString(2, date);
@@ -191,56 +190,52 @@ public class TestBostonUPSTrackingJob implements Job {
                 if (r != 2) {//number of subkits
                     logger.error("Update query for UPS tracking updated " + r + " rows! with tracking/return id: " + trackingId);
                 }
+
+                if (!isReturn) {
+                    if (shouldTriggerEventForKitOnItsWayToParticipant(statusType, oldType)) {
+                        KitDDPNotification kitDDPNotification = KitDDPNotification.getKitDDPNotification(SQL_SELECT_KIT_FOR_NOTIFICATION_EXTERNAL_SHIPPER + SELECT_BY_TRACKING_NUMBER, new String[] { DELIVERED, trackingId }, 2);//todo change this to the number of subkits but for now 2 for test boston works
+                        if (kitDDPNotification != null) {
+                            logger.info("Triggering DDP for kit going to participant with external order number: " + kit.getExternalOrderNumber());
+                            EventUtil.triggerDDP(conn, kitDDPNotification);
+                        }
+                        else {
+                            logger.error("delivered kitDDPNotification was null for " + kit.getExternalOrderNumber());
+                        }
+                    }
+
+                }
+                else { // this is a return
+                    if (earliestInTransitTime != null && !kit.isCEOrdered()) {
+                        // if we have the first date of an inbound event, create an order in CE
+                        // using the earliest date of inbound event
+                        orderRegistrar.orderTest(DSMServer.careEvolveAuth, kit.getHRUID(), kit.getKitLabel(), kit.getExternalOrderNumber(), earliestInTransitTime);
+                        logger.info("Placed CE order for kit with external order number " + kit.getExternalOrderNumber());
+                        kit.changeCEOrdered(true);
+                    }
+                    else {
+                        logger.info("No return events for " + kit.getKitLabel() + ".  Will not place order yet.");
+                    }
+                    if (shouldTriggerEventForReturnKitDelivery(statusType, oldType)) {
+                        KitUtil.setKitReceived(kit.getKitLabel());
+                        logger.info("RECEIVED: " + trackingId);
+                        KitDDPNotification kitDDPNotification = KitDDPNotification.getKitDDPNotification(SQL_SELECT_KIT_FOR_NOTIFICATION_EXTERNAL_SHIPPER + SELECT_BY_RETURN_NUMBER, new String[] { RECEIVED, trackingId }, 2);//todo change this to the number of subkits but for now 2 for test boston works
+                        if (kitDDPNotification != null) {
+                            logger.info("Triggering DDP for received kit with external order number: " + kit.getExternalOrderNumber());
+                            EventUtil.triggerDDP(conn, kitDDPNotification);
+
+                        }
+                        else {
+                            logger.error("received kitDDPNotification was null for " + kit.getExternalOrderNumber());
+                        }
+                    }
+                }
+                logger.info("Updated status of tracking number " + trackingId + " to " + upsUpdate + " from " + oldType);
             }
             catch (Exception e) {
-                dbVals.resultException = e;
+                throw new RuntimeException("Could not update tracking info for tracking id " + trackingId, e);
             }
-            return dbVals;
+            return null;
         });
-        if (result.resultException != null) {
-            throw new RuntimeException(result.resultException);
-        }
-        else {
-            if (!isReturn) {
-                if (shouldTriggerEventForKitOnItsWayToParticipant(statusType, oldType)) {
-                    KitDDPNotification kitDDPNotification = KitDDPNotification.getKitDDPNotification(SQL_SELECT_KIT_FOR_NOTIFICATION_EXTERNAL_SHIPPER + SELECT_BY_TRACKING_NUMBER, new String[] { DELIVERED, trackingId }, 2);//todo change this to the number of subkits but for now 2 for test boston works
-                    if (kitDDPNotification != null) {
-                        logger.info("Triggering DDP for kit going to participant with external order number: " + kit.getExternalOrderNumber());
-                        EventUtil.triggerDDP(kitDDPNotification);
-                    }
-                    else {
-                        logger.error("delivered kitDDPNotification was null for " + kit.getExternalOrderNumber());
-                    }
-                }
-
-            }
-            else { // this is a return
-                if (earliestInTransitTime != null && !kit.isCEOrdered()) {
-                    // if we have the first date of an inbound event, create an order in CE
-                    // using the earliest date of inbound event
-                    orderRegistrar.orderTest(DSMServer.careEvolveAuth, kit.getHRUID(), kit.getKitLabel(), kit.getExternalOrderNumber(), earliestInTransitTime);
-                    logger.info("Placed CE order for kit with external order number " + kit.getExternalOrderNumber());
-                    kit.changeCEOrdered(true);
-                }
-                else {
-                    logger.info("No return events for " + kit.getKitLabel() + ".  Will not place order yet.");
-                }
-                if (shouldTriggerEventForReturnKitDelivery(statusType, oldType)) {
-                    KitUtil.setKitReceived(kit.getKitLabel());
-                    logger.info("RECEIVED: " + trackingId);
-                    KitDDPNotification kitDDPNotification = KitDDPNotification.getKitDDPNotification(SQL_SELECT_KIT_FOR_NOTIFICATION_EXTERNAL_SHIPPER + SELECT_BY_RETURN_NUMBER, new String[] { RECEIVED, trackingId }, 2);//todo change this to the number of subkits but for now 2 for test boston works
-                    if (kitDDPNotification != null) {
-                        logger.info("Triggering DDP for received kit with external order number: " + kit.getExternalOrderNumber());
-                        EventUtil.triggerDDP(kitDDPNotification);
-
-                    }
-                    else {
-                        logger.error("received kitDDPNotification was null for " + kit.getExternalOrderNumber());
-                    }
-                }
-            }
-            logger.info("Updated status of tracking number " + trackingId + " to " + upsUpdate + " from " + oldType);
-        }
     }
 
     /**

--- a/src/main/java/org/broadinstitute/dsm/model/KitRequestExternal.java
+++ b/src/main/java/org/broadinstitute/dsm/model/KitRequestExternal.java
@@ -29,28 +29,20 @@ public class KitRequestExternal extends KitRequest {
     }
 
     // update kit request with status and date of external shipper
-    public static void updateKitRequest(String externalOrderStatus, long externalOrderDate, String dsmKitRequestId) {
-        SimpleResult results = inTransaction((conn) -> {
-            SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement stmt = conn.prepareStatement(SQL_UPDATE_KIT_REQUEST_EXTERNAL_SHIPPER_STATUS)) {
-                stmt.setString(1, externalOrderStatus);
-                stmt.setLong(2, externalOrderDate);
-                stmt.setString(3, dsmKitRequestId);
-                stmt.setString(4, externalOrderStatus);
+    public static void updateKitRequest(Connection conn, String externalOrderStatus, long externalOrderDate, String dsmKitRequestId) {
+        try (PreparedStatement stmt = conn.prepareStatement(SQL_UPDATE_KIT_REQUEST_EXTERNAL_SHIPPER_STATUS)) {
+            stmt.setString(1, externalOrderStatus);
+            stmt.setLong(2, externalOrderDate);
+            stmt.setString(3, dsmKitRequestId);
+            stmt.setString(4, externalOrderStatus);
 
-                int result = stmt.executeUpdate();
-                if (result > 1) {
-                    throw new RuntimeException("Error updating kit request w/ dsm_kit_request_id " + dsmKitRequestId + " it was updating " + result + " rows");
-                }
+            int result = stmt.executeUpdate();
+            if (result > 1) {
+                throw new RuntimeException("Error updating kit request w/ dsm_kit_request_id " + dsmKitRequestId + " it was updating " + result + " rows");
             }
-            catch (Exception e) {
-                dbVals.resultException = e;
-            }
-            return dbVals;
-        });
-
-        if (results.resultException != null) {
-            logger.error("Error updating kit request w/ dsm_kit_request_id " + dsmKitRequestId, results.resultException);
+        }
+        catch (Exception e) {
+           throw new RuntimeException("Error updating kit request w/ dsm_kit_request_id " + dsmKitRequestId, e);
         }
     }
 

--- a/src/main/java/org/broadinstitute/dsm/route/BSPKitQueryRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/BSPKitQueryRoute.java
@@ -22,6 +22,7 @@ import spark.Request;
 import spark.Response;
 import spark.Route;
 
+import java.sql.Connection;
 import java.util.*;
 
 public class BSPKitQueryRoute implements Route {
@@ -40,10 +41,13 @@ public class BSPKitQueryRoute implements Route {
         if (StringUtils.isBlank(kitLabel)) {
             throw new RuntimeException("Please include a kit label as a path parameter");
         }
-        return getBSPKitInfo(kitLabel, response);
+
+        return TransactionWrapper.inTransaction(conn -> {
+            return getBSPKitInfo(conn, kitLabel, response);
+        });
     }
 
-    public Object getBSPKitInfo(@NonNull String kitLabel, @NonNull Response response) {
+    public Object getBSPKitInfo(Connection conn, @NonNull String kitLabel, @NonNull Response response) {
         logger.info("Checking label " + kitLabel);
         BSPKitQueryResult bspKitInfo = BSPKitQueryResult.getBSPKitQueryResult(kitLabel);
 
@@ -95,12 +99,12 @@ public class BSPKitQueryRoute implements Route {
                         }
                     }
                     else {
-                        triggerDDP(bspKitInfo, firstTimeReceived, kitLabel);
+                        triggerDDP(conn, bspKitInfo, firstTimeReceived, kitLabel);
                     }
                 }
             }
             else {
-                triggerDDP(bspKitInfo, firstTimeReceived, kitLabel);
+                triggerDDP(conn, bspKitInfo, firstTimeReceived, kitLabel);
             }
 
             String bspParticipantId = bspKitInfo.getBspParticipantId();
@@ -129,12 +133,12 @@ public class BSPKitQueryRoute implements Route {
         }
     }
 
-    private void triggerDDP(@NonNull BSPKitQueryResult bspKitInfo, boolean firstTimeReceived, String kitLabel) {
+    private void triggerDDP(Connection conn, @NonNull BSPKitQueryResult bspKitInfo, boolean firstTimeReceived, String kitLabel) {
         try {
             if (bspKitInfo.isHasParticipantNotifications() && firstTimeReceived) {
                 KitDDPNotification kitDDPNotification = KitDDPNotification.getKitDDPNotification(TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.GET_RECEIVED_KIT_INFORMATION_FOR_NOTIFICATION_EMAIL), kitLabel, 1);
                 if (kitDDPNotification != null) {
-                    EventUtil.triggerDDP(kitDDPNotification);
+                    EventUtil.triggerDDP(conn, kitDDPNotification);
                 }
             }
         }

--- a/src/main/java/org/broadinstitute/dsm/route/KitStatusChangeRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/KitStatusChangeRoute.java
@@ -138,7 +138,7 @@ public class KitStatusChangeRoute extends RequestHandler {
                         logger.info("Updated kitRequests w/ ddp_label " + kit);
                         KitDDPNotification kitDDPNotification = KitDDPNotification.getKitDDPNotification(TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.GET_SENT_KIT_INFORMATION_FOR_NOTIFICATION_EMAIL), kit, 1);
                         if (kitDDPNotification != null) {
-                            EventUtil.triggerDDP(kitDDPNotification);
+                            EventUtil.triggerDDP(conn, kitDDPNotification);
                         }
                     }
                     else if (RoutePath.TRACKING_SCAN_REQUEST.equals(changeType)) {

--- a/src/main/java/org/broadinstitute/dsm/util/EventUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/EventUtil.java
@@ -2,6 +2,7 @@ package org.broadinstitute.dsm.util;
 
 import lombok.NonNull;
 import org.broadinstitute.ddp.db.SimpleResult;
+import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.dsm.db.ParticipantEvent;
 import org.broadinstitute.dsm.model.KitDDPNotification;
 import org.broadinstitute.dsm.model.TestResultEvent;
@@ -14,6 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -43,7 +45,10 @@ public class EventUtil {
         Collection<KitDDPNotification> kitDDPNotifications = getKitsNotReceived();
         for (KitDDPNotification kitInfo : kitDDPNotifications) {
             if (KitDDPNotification.REMINDER.equals(kitInfo.getEventType())) {
-                triggerDDP(kitInfo);
+                TransactionWrapper.inTransaction(conn -> {
+                    triggerDDP(conn, kitInfo);
+                    return null;
+                });
             }
         }
     }
@@ -83,85 +88,77 @@ public class EventUtil {
         return kitDDPNotifications;
     }
 
-    public static void triggerDDP(@NonNull KitDDPNotification kitDDPNotification) {
+    public static void triggerDDP(Connection conn,@NonNull KitDDPNotification kitDDPNotification) {
         Collection<String> events = ParticipantEvent.getParticipantEvent(kitDDPNotification.getParticipantId(), kitDDPNotification.getDdpInstanceId());
         if (!events.contains(kitDDPNotification.getEventName())) {
-            EventUtil.triggerDDP(kitDDPNotification.getEventName(), kitDDPNotification);
+            EventUtil.triggerDDP(conn, kitDDPNotification.getEventName(), kitDDPNotification);
         }
         else {
             logger.info("Participant direct event was added in the participant_event table. DDP will not get triggered");
             //to add these events also to the event table, but without triggering the ddp and flag EVENT_TRIGGERED = false
-            addEvent(kitDDPNotification.getEventName(), kitDDPNotification.getDdpInstanceId(), kitDDPNotification.getDsmKitRequestId(), false);
+            addEvent(conn, kitDDPNotification.getEventName(), kitDDPNotification.getDdpInstanceId(), kitDDPNotification.getDsmKitRequestId(), false);
         }
     }
 
-    public static void triggerDDPWithTestResult(@NonNull KitDDPNotification kitDDPNotification, @Nonnull TestBostonResult result) {
+    public static void triggerDDPWithTestResult(Connection conn,@NonNull KitDDPNotification kitDDPNotification, @Nonnull TestBostonResult result) {
         Collection<String> events = ParticipantEvent.getParticipantEvent(kitDDPNotification.getParticipantId(), kitDDPNotification.getDdpInstanceId());
         if (!events.contains(kitDDPNotification.getEventName())) {
-            EventUtil.triggerDDPWithTestResult(kitDDPNotification.getEventName(), kitDDPNotification, result);
+            EventUtil.triggerDDPWithTestResult(conn, kitDDPNotification.getEventName(), kitDDPNotification, result);
         }
         else {
             logger.info("Participant direct event was added in the participant_event table. DDP will not get triggered");
             //to add these events also to the event table, but without triggering the ddp and flag EVENT_TRIGGERED = false
-            addEvent(kitDDPNotification.getEventName(), kitDDPNotification.getDdpInstanceId(), kitDDPNotification.getDsmKitRequestId(), false);
+            addEvent(conn, kitDDPNotification.getEventName(), kitDDPNotification.getDdpInstanceId(), kitDDPNotification.getDsmKitRequestId(), false);
         }
     }
 
-    private static void triggerDDP(@NonNull String eventType, @NonNull KitDDPNotification kitInfo) {
+    private static void triggerDDP(Connection conn, @NonNull String eventType, @NonNull KitDDPNotification kitInfo) {
         try {
             KitEvent event = new KitEvent(kitInfo.getParticipantId(), eventType, kitInfo.getDate() / 1000, kitInfo.getUploadReason(), kitInfo.getDdpKitRequestId());
             String sendRequest = kitInfo.getBaseUrl() + RoutePath.DDP_PARTICIPANT_EVENT_PATH + "/" + kitInfo.getParticipantId();
             DDPRequestUtil.postRequest(sendRequest, event, kitInfo.getInstanceName(), kitInfo.isHasAuth0Token());
-            addEvent(eventType, kitInfo.getDdpInstanceId(), kitInfo.getDsmKitRequestId());
+            addEvent(conn, eventType, kitInfo.getDdpInstanceId(), kitInfo.getDsmKitRequestId());
         }
         catch (IOException e) {
             logger.error("Failed to trigger DDP to notify participant about " + eventType);
             //to add these events also to the event table, but without triggering the ddp and flag EVENT_TRIGGERED = false
-            addEvent(eventType, kitInfo.getDdpInstanceId(), kitInfo.getDsmKitRequestId(), false);
+            addEvent(conn, eventType, kitInfo.getDdpInstanceId(), kitInfo.getDsmKitRequestId(), false);
         }
     }
 
-    private static void triggerDDPWithTestResult(@NonNull String eventType, @NonNull KitDDPNotification kitInfo, @Nonnull TestBostonResult result) {
+    private static void triggerDDPWithTestResult(Connection conn,@NonNull String eventType, @NonNull KitDDPNotification kitInfo, @Nonnull TestBostonResult result) {
         try {
             DSMTestResult dsmTestResult = new DSMTestResult(result.getResult(), result.getTimeCompleted(), result.isCorrected());
             TestResultEvent event = new TestResultEvent(kitInfo.getParticipantId(), eventType, kitInfo.getDate() / 1000,kitInfo.getUploadReason(), kitInfo.getDdpKitRequestId(),  dsmTestResult);
             String sendRequest = kitInfo.getBaseUrl() + RoutePath.DDP_PARTICIPANT_EVENT_PATH + "/" + kitInfo.getParticipantId();
             DDPRequestUtil.postRequest(sendRequest, event, kitInfo.getInstanceName(), kitInfo.isHasAuth0Token());
-            addEvent(eventType, kitInfo.getDdpInstanceId(), kitInfo.getDsmKitRequestId());
+            addEvent(conn, eventType, kitInfo.getDdpInstanceId(), kitInfo.getDsmKitRequestId());
         }
         catch (IOException e) {
             logger.error("Failed to trigger DDP to notify participant about " + eventType);
             //to add these events also to the event table, but without triggering the ddp and flag EVENT_TRIGGERED = false
-            addEvent(eventType, kitInfo.getDdpInstanceId(), kitInfo.getDsmKitRequestId(), false);
+            addEvent(conn, eventType, kitInfo.getDdpInstanceId(), kitInfo.getDsmKitRequestId(), false);
         }
     }
 
-    private static void addEvent(@NonNull String type, @NonNull String instanceID, @NonNull String requestId) {
-        addEvent(type, instanceID, requestId, true);
+    private static void addEvent(Connection conn, @NonNull String type, @NonNull String instanceID, @NonNull String requestId) {
+        addEvent(conn, type, instanceID, requestId, true);
     }
 
-    public static void addEvent(@NonNull String type, @NonNull String instanceID, @NonNull String requestId, boolean trigger) {
-        SimpleResult results = inTransaction((conn) -> {
-            SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement stmt = conn.prepareStatement(SQL_INSERT_EVENT)) {
-                stmt.setLong(1, System.currentTimeMillis());
-                stmt.setString(2, type);
-                stmt.setString(3, instanceID);
-                stmt.setString(4, requestId);
-                stmt.setBoolean(5, trigger);
-                int result = stmt.executeUpdate();
-                if (result != 1) {
-                    throw new RuntimeException("Error could not add event for kit request " + requestId);
-                }
+    public static void addEvent(Connection conn, @NonNull String type, @NonNull String instanceID, @NonNull String requestId, boolean trigger) {
+        try (PreparedStatement stmt = conn.prepareStatement(SQL_INSERT_EVENT)) {
+            stmt.setLong(1, System.currentTimeMillis());
+            stmt.setString(2, type);
+            stmt.setString(3, instanceID);
+            stmt.setString(4, requestId);
+            stmt.setBoolean(5, trigger);
+            int result = stmt.executeUpdate();
+            if (result != 1) {
+                throw new RuntimeException("Error could not add event for kit request " + requestId);
             }
-            catch (SQLException e) {
-                dbVals.resultException = e;
-            }
-            return dbVals;
-        });
-
-        if (results.resultException != null) {
-            logger.error("Error inserting event ", results.resultException);
+        }
+        catch (SQLException e) {
+            logger.error("Error inserting event ", e);
         }
     }
 }

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/ExternalShipper.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/ExternalShipper.java
@@ -12,12 +12,14 @@ public interface ExternalShipper {
 
     public void orderKitRequests(ArrayList<KitRequest> kitRequests, EasyPostUtil easyPostUtil, KitRequestSettings kitRequestSettings, String shippingCarrier) throws Exception;
 
-    public void orderStatus(ArrayList<KitRequest> kitRequests) throws Exception;
+    /**
+     * Checks for incomplete orders and updates the internal status
+     * of the order
+     */
+    void updateOrderStatusForPendingKitRequests(int instanceId);
 
     public void orderConfirmation(long startDate, long endDate) throws Exception;
 
     public void orderCancellation(ArrayList<KitRequest> kitRequests) throws Exception;
-
-    public  ArrayList<KitRequest> getKitRequestsNotDone(int instanceId);
 
 }

--- a/src/test/java/org/broadinstitute/dsm/QuartzExternalShipperTest.java
+++ b/src/test/java/org/broadinstitute/dsm/QuartzExternalShipperTest.java
@@ -64,7 +64,7 @@ public class QuartzExternalShipperTest extends TestHelper {
     public void externalShipperJob() throws Exception {
 //        uploadKit();
 
-        ExternalShipper shipper = (ExternalShipper) Class.forName(DSMServer.getClassName("gbf")).newInstance();//GBFRequestUtil
+        GBFRequestUtil shipper = new GBFRequestUtil();
         ArrayList<KitRequest> kitRequests = shipper.getKitRequestsNotDone(15);
         Map<Integer, KitRequestSettings> kitRequestSettingsMap = KitRequestSettings.getKitRequestSettings("15");
         shipper.orderKitRequests(kitRequests, new EasyPostUtil("testboston"), kitRequestSettingsMap.get(11), null       );


### PR DESCRIPTION
For DDP-5479, Instead of extracting long lists of `KitRequests` and passing them around--which is contributing to memory pressure--these changes stream things a bit more so that as we work through the result set of pending kits, we update its status from GBF as we go.

While making these changes, I found another latent bug that can result in inconsistent transactions.  I fixed this by passing around `Connection`s, which rippled through a number of classes unrelated to the driving changes above.

I also suspect that some of our larger log statements--which pull fairly large objects into a `String`--may be contributing to our problems, so I removed those.