### PR TITLE
DDP-5479 Reducing the number of calls we make to GBF status endpoint

### DIFF
--- a/appengine/deploy/StudyManager.tmpl.yaml
+++ b/appengine/deploy/StudyManager.tmpl.yaml
@@ -11,7 +11,7 @@ vpc_access_connector:
 network:
   instance_tag: study-manager
 
-entrypoint: java -javaagent:tcell/tcellagent.jar -Xms820m -Xmx820m -Dlog4j.configurationFile=log4j.xml -jar DSMServer.jar
+entrypoint: java -javaagent:tcell/tcellagent.jar -Xms1640m -Xmx1640m -Dlog4j.configurationFile=log4j.xml -jar DSMServer.jar
 
 env_variables:
   TCELL_AGENT_HOST_IDENTIFIER: study-manager

--- a/appengine/deploy/StudyManager.tmpl.yaml
+++ b/appengine/deploy/StudyManager.tmpl.yaml
@@ -11,7 +11,7 @@ vpc_access_connector:
 network:
   instance_tag: study-manager
 
-entrypoint: java -javaagent:tcell/tcellagent.jar -Xms1640m -Xmx1640m -Dlog4j.configurationFile=log4j.xml -jar DSMServer.jar
+entrypoint: java -javaagent:tcell/tcellagent.jar -agentpath:/opt/cprof/profiler_java_agent.so=-cprof_enable_heap_sampling=true,-cprof_service=study-manager,-cprof_cpu_use_per_thread_timers=true,-logtostderr -Xms1640m -Xmx1640m -Dlog4j.configurationFile=log4j.xml -jar DSMServer.jar
 
 env_variables:
   TCELL_AGENT_HOST_IDENTIFIER: study-manager

--- a/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -164,7 +164,7 @@ public class DSMServer extends BasicServer {
     protected void configureServer(@NonNull Config config) {
         logger.info("Property source: " + config.getString("portal.environment"));
         logger.info("Configuring the server...");
-        threadPool(-1, -1, 30000);
+        threadPool(-1, -1, 60000);
         int port = config.getInt("portal.port");
         String appEnginePort = System.getenv("PORT");
 

--- a/src/main/java/org/broadinstitute/dsm/db/DdpKit.java
+++ b/src/main/java/org/broadinstitute/dsm/db/DdpKit.java
@@ -5,6 +5,7 @@ import org.broadinstitute.ddp.db.SimpleResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 
 import static org.broadinstitute.ddp.db.TransactionWrapper.inTransaction;
@@ -47,29 +48,20 @@ public class DdpKit {
         this.CEOrdered = CEOrdered;
     }
 
-    public void changeCEOrdered(boolean orderStatus) {
+    public void changeCEOrdered(Connection conn, boolean orderStatus) {
         String query = "UPDATE ddp_kit SET CE_order = ? where dsm_kit_request_id = ?";
-        SimpleResult result = inTransaction((conn) -> {
-            SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement stmt = conn.prepareStatement(query)) {
-                stmt.setBoolean(1, orderStatus);
-                stmt.setString(2, this.getDsmKitRequestId());
-                int r = stmt.executeUpdate();
-                if (r != 1) {//number of subkits
-                    throw new RuntimeException("Update query for CE order flag updated " + r + " rows! with dsm kit request id: " + this.getDsmKitRequestId());
-                }
+        try (PreparedStatement stmt = conn.prepareStatement(query)) {
+            stmt.setBoolean(1, orderStatus);
+            stmt.setString(2, this.getDsmKitRequestId());
+            int r = stmt.executeUpdate();
+            if (r != 1) {//number of subkits
+                throw new RuntimeException("Update query for CE order flag updated " + r + " rows! with dsm kit request id: " + this.getDsmKitRequestId());
             }
-            catch (Exception e) {
-                dbVals.resultException = e;
-            }
-            return dbVals;
-        });
-        if (result.resultException != null) {
-            throw new RuntimeException(result.resultException);
-        }
-        else {
             logger.info("Updated CE_Order value for kit with dsm kit request id " + this.getDsmKitRequestId()
                     + " to " + orderStatus);
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Could not update ce_ordered status for " + this.getDsmKitRequestId(),e);
         }
     }
 

--- a/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
+++ b/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
@@ -42,12 +42,11 @@ public class KitRequestShipping extends KitRequest {
             "request.kit_type_id, request.external_order_status, request.external_order_number, request.external_order_date, request.external_response, request.upload_reason, kt.no_return, request.created_by, " +
             "kit.dsm_kit_request_id, kit.dsm_kit_id, kit.kit_complete, kit.label_url_to, kit.label_url_return, kit.tracking_to_id, " +
             "kit.tracking_return_id, kit.easypost_tracking_to_url, kit.easypost_tracking_return_url, kit.easypost_to_id, kit.easypost_shipment_status, kit.scan_date, kit.label_date, kit.error, kit.message, " +
-            "kit.receive_date, kit.deactivated_date, kit.easypost_address_id_to, kit.deactivation_reason, tracking.tracking_id, kit.kit_label, kit.express, kit.test_result, kit.needs_approval, kit.authorization, kit.denial_reason, " +
+            "kit.receive_date, kit.deactivated_date, kit.easypost_address_id_to, kit.deactivation_reason, (select t.tracking_id from ddp_kit_tracking t where t.kit_label = kit.kit_label) as tracking_id, kit.kit_label, kit.express, kit.test_result, kit.needs_approval, kit.authorization, kit.denial_reason, " +
             "kit.authorized_by, kit.ups_tracking_status, kit.ups_return_status, kit.CE_order " +
             "FROM ddp_kit_request request " +
             "LEFT JOIN ddp_kit kit on (kit.dsm_kit_request_id = request.dsm_kit_request_id) " +
             "LEFT JOIN ddp_instance realm on (realm.ddp_instance_id = request.ddp_instance_id) " +
-            "LEFT JOIN ddp_kit_tracking tracking ON (kit.kit_label = tracking.kit_label) " +
             "LEFT JOIN kit_type kt on (request.kit_type_id = kt.kit_type_id) ";
     public static final String SQL_SELECT_KIT_REQUEST = "SELECT * FROM ( SELECT req.upload_reason, kt.kit_type_name, ddp_site.instance_name, ddp_site.ddp_instance_id, ddp_site.base_url, ddp_site.auth0_token, ddp_site.billing_reference, " +
             "ddp_site.migrated_ddp, ddp_site.collaborator_id_prefix, ddp_site.es_participant_index, req.bsp_collaborator_participant_id, req.bsp_collaborator_sample_id, req.ddp_participant_id, req.ddp_label, req.dsm_kit_request_id, " +

--- a/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
+++ b/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
@@ -38,6 +38,17 @@ public class KitRequestShipping extends KitRequest {
 
     private static final Logger logger = LoggerFactory.getLogger(KitRequestShipping.class);
 
+    public static final String SQL_SELECT_KIT_REQUEST_NEW = "SELECT kt.kit_type_name, realm.instance_name, request.bsp_collaborator_participant_id, request.bsp_collaborator_sample_id, request.ddp_participant_id, request.ddp_label, request.dsm_kit_request_id, " +
+            "request.kit_type_id, request.external_order_status, request.external_order_number, request.external_order_date, request.external_response, request.upload_reason, kt.no_return, request.created_by, " +
+            "kit.dsm_kit_request_id, kit.dsm_kit_id, kit.kit_complete, kit.label_url_to, kit.label_url_return, kit.tracking_to_id, " +
+            "kit.tracking_return_id, kit.easypost_tracking_to_url, kit.easypost_tracking_return_url, kit.easypost_to_id, kit.easypost_shipment_status, kit.scan_date, kit.label_date, kit.error, kit.message, " +
+            "kit.receive_date, kit.deactivated_date, kit.easypost_address_id_to, kit.deactivation_reason, tracking.tracking_id, kit.kit_label, kit.express, kit.test_result, kit.needs_approval, kit.authorization, kit.denial_reason, " +
+            "kit.authorized_by, kit.ups_tracking_status, kit.ups_return_status, kit.CE_order " +
+            "FROM ddp_kit_request request " +
+            "LEFT JOIN ddp_kit kit on (kit.dsm_kit_request_id = request.dsm_kit_request_id) " +
+            "LEFT JOIN ddp_instance realm on (realm.ddp_instance_id = request.ddp_instance_id) " +
+            "LEFT JOIN ddp_kit_tracking tracking ON (kit.kit_label = tracking.kit_label) " +
+            "LEFT JOIN kit_type kt on (request.kit_type_id = kt.kit_type_id) ";
     public static final String SQL_SELECT_KIT_REQUEST = "SELECT * FROM ( SELECT req.upload_reason, kt.kit_type_name, ddp_site.instance_name, ddp_site.ddp_instance_id, ddp_site.base_url, ddp_site.auth0_token, ddp_site.billing_reference, " +
             "ddp_site.migrated_ddp, ddp_site.collaborator_id_prefix, ddp_site.es_participant_index, req.bsp_collaborator_participant_id, req.bsp_collaborator_sample_id, req.ddp_participant_id, req.ddp_label, req.dsm_kit_request_id, " +
             "req.kit_type_id, req.external_order_status, req.external_order_number, req.external_order_date, req.external_response, kt.no_return, req.created_by FROM kit_type kt, ddp_kit_request req, ddp_instance ddp_site " +
@@ -259,16 +270,17 @@ public class KitRequestShipping extends KitRequest {
                 rs.getString(DBConstants.UPS_TRACKING_STATUS),
                 rs.getString(DBConstants.UPS_RETURN_STATUS),
                 rs.getLong(DBConstants.EXTERNAL_ORDER_DATE),
-                rs.getBoolean(DBConstants.CARE_EVOLVE),rs.getString(DBConstants.UPLOAD_REASON)
+                rs.getBoolean(DBConstants.CARE_EVOLVE),
+                rs.getString(DBConstants.UPLOAD_REASON)
         );
         return kitRequestShipping;
     }
 
-    public static Map<String, List<KitRequestShipping>> getKitRequests(@NonNull String realm) {
-        return getKitRequests(realm, null);
+    public static Map<String, List<KitRequestShipping>> getKitRequests(@NonNull DDPInstance instance) {
+        return getKitRequests(instance, null);
     }
 
-    public static Map<String, List<KitRequestShipping>> getKitRequests(@NonNull String realm, String queryAddition) {
+    public static Map<String, List<KitRequestShipping>> getKitRequests(@NonNull DDPInstance instance, String queryAddition) {
         logger.info("Collection sample information");
         Map<String, List<KitRequestShipping>> kitRequests = new HashMap<>();
         SimpleResult results = inTransaction((conn) -> {
@@ -277,8 +289,8 @@ public class KitRequestShipping extends KitRequest {
             if (StringUtils.isNotBlank(addition)) {
                 addition = addition.replaceAll("k\\.", "");
             }
-            try (PreparedStatement stmt = conn.prepareStatement(DBUtil.getFinalQuery(SQL_SELECT_KIT_REQUEST.concat(QueryExtension.BY_REALM), addition))) {
-                stmt.setString(1, realm);
+            try (PreparedStatement stmt = conn.prepareStatement(DBUtil.getFinalQuery(SQL_SELECT_KIT_REQUEST_NEW.concat(QueryExtension.WHERE_REALM_INSTANCE_ID), addition))) {
+                stmt.setString(1, instance.getDdpInstanceId());
                 try (ResultSet rs = stmt.executeQuery()) {
                     while (rs.next()) {
                         addKitRequest(rs, kitRequests);
@@ -294,7 +306,7 @@ public class KitRequestShipping extends KitRequest {
         if (results.resultException != null) {
             throw new RuntimeException("Couldn't get list of samples ", results.resultException);
         }
-        logger.info("Got " + kitRequests.size() + " participants samples in DSM DB for " + realm);
+        logger.info("Got " + kitRequests.size() + " participants samples in DSM DB for " + instance.getName());
         return kitRequests;
     }
 

--- a/src/main/java/org/broadinstitute/dsm/jobs/ExternalShipperJob.java
+++ b/src/main/java/org/broadinstitute/dsm/jobs/ExternalShipperJob.java
@@ -25,9 +25,7 @@ public class ExternalShipperJob implements Job {
             try {
                 logger.info("Starting the external shipper job");
                 ExternalShipper shipper = (ExternalShipper) Class.forName(DSMServer.getClassName(kitType.getExternalShipper())).newInstance();//GBFRequestUtil
-                ArrayList<KitRequest> kitRequests = shipper.getKitRequestsNotDone(kitType.getInstanceId());
-                shipper.orderStatus(kitRequests);
-                kitRequests.clear();
+                shipper.updateOrderStatusForPendingKitRequests(kitType.getInstanceId());
                 Instant now = Instant.now();
                 Instant dynamicStartTime = now.minus(5, ChronoUnit.DAYS);
                 shipper.orderConfirmation(dynamicStartTime.toEpochMilli(), now.toEpochMilli());

--- a/src/main/java/org/broadinstitute/dsm/jobs/ExternalShipperJob.java
+++ b/src/main/java/org/broadinstitute/dsm/jobs/ExternalShipperJob.java
@@ -27,6 +27,7 @@ public class ExternalShipperJob implements Job {
                 ExternalShipper shipper = (ExternalShipper) Class.forName(DSMServer.getClassName(kitType.getExternalShipper())).newInstance();//GBFRequestUtil
                 ArrayList<KitRequest> kitRequests = shipper.getKitRequestsNotDone(kitType.getInstanceId());
                 shipper.orderStatus(kitRequests);
+                kitRequests.clear();
                 Instant now = Instant.now();
                 Instant dynamicStartTime = now.minus(5, ChronoUnit.DAYS);
                 shipper.orderConfirmation(dynamicStartTime.toEpochMilli(), now.toEpochMilli());

--- a/src/main/java/org/broadinstitute/dsm/jobs/ExternalShipperJob.java
+++ b/src/main/java/org/broadinstitute/dsm/jobs/ExternalShipperJob.java
@@ -3,17 +3,12 @@ package org.broadinstitute.dsm.jobs;
 import org.broadinstitute.dsm.DSMServer;
 import org.broadinstitute.dsm.model.KitRequest;
 import org.broadinstitute.dsm.model.KitType;
-import org.broadinstitute.dsm.statics.DBConstants;
-import org.broadinstitute.dsm.util.DBUtil;
 import org.broadinstitute.dsm.util.externalShipper.ExternalShipper;
-import org.quartz.CronExpression;
 import org.quartz.Job;
-import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -32,12 +27,9 @@ public class ExternalShipperJob implements Job {
                 ExternalShipper shipper = (ExternalShipper) Class.forName(DSMServer.getClassName(kitType.getExternalShipper())).newInstance();//GBFRequestUtil
                 ArrayList<KitRequest> kitRequests = shipper.getKitRequestsNotDone(kitType.getInstanceId());
                 shipper.orderStatus(kitRequests);
-                if (kitRequests != null && !kitRequests.isEmpty()) { // only if there are kits which are not yet having kit_label set
-                    logger.info("Working on " + kitRequests.size() + " incomplete external kits");
-                    Instant now = Instant.now();
-                    Instant dynamicStartTime = now.minus(5, ChronoUnit.DAYS);
-                    shipper.orderConfirmation(kitRequests, dynamicStartTime.toEpochMilli(), now.toEpochMilli());
-                }
+                Instant now = Instant.now();
+                Instant dynamicStartTime = now.minus(5, ChronoUnit.DAYS);
+                shipper.orderConfirmation(dynamicStartTime.toEpochMilli(), now.toEpochMilli());
             }
             catch (Exception e) {
                 throw new RuntimeException("Failed to get status and/or confirmation ", e);

--- a/src/main/java/org/broadinstitute/dsm/jobs/TestBostonUPSTrackingJob.java
+++ b/src/main/java/org/broadinstitute/dsm/jobs/TestBostonUPSTrackingJob.java
@@ -193,7 +193,7 @@ public class TestBostonUPSTrackingJob implements Job {
 
                 if (!isReturn) {
                     if (shouldTriggerEventForKitOnItsWayToParticipant(statusType, oldType)) {
-                        KitDDPNotification kitDDPNotification = KitDDPNotification.getKitDDPNotification(SQL_SELECT_KIT_FOR_NOTIFICATION_EXTERNAL_SHIPPER + SELECT_BY_TRACKING_NUMBER, new String[] { DELIVERED, trackingId }, 2);//todo change this to the number of subkits but for now 2 for test boston works
+                        KitDDPNotification kitDDPNotification = KitDDPNotification.getKitDDPNotification(conn,SQL_SELECT_KIT_FOR_NOTIFICATION_EXTERNAL_SHIPPER + SELECT_BY_TRACKING_NUMBER, new String[] { DELIVERED, trackingId }, 2);//todo change this to the number of subkits but for now 2 for test boston works
                         if (kitDDPNotification != null) {
                             logger.info("Triggering DDP for kit going to participant with external order number: " + kit.getExternalOrderNumber());
                             EventUtil.triggerDDP(conn, kitDDPNotification);
@@ -210,15 +210,15 @@ public class TestBostonUPSTrackingJob implements Job {
                         // using the earliest date of inbound event
                         orderRegistrar.orderTest(DSMServer.careEvolveAuth, kit.getHRUID(), kit.getKitLabel(), kit.getExternalOrderNumber(), earliestInTransitTime);
                         logger.info("Placed CE order for kit with external order number " + kit.getExternalOrderNumber());
-                        kit.changeCEOrdered(true);
+                        kit.changeCEOrdered(conn,true);
                     }
                     else {
                         logger.info("No return events for " + kit.getKitLabel() + ".  Will not place order yet.");
                     }
                     if (shouldTriggerEventForReturnKitDelivery(statusType, oldType)) {
-                        KitUtil.setKitReceived(kit.getKitLabel());
+                        KitUtil.setKitReceived(conn, kit.getKitLabel());
                         logger.info("RECEIVED: " + trackingId);
-                        KitDDPNotification kitDDPNotification = KitDDPNotification.getKitDDPNotification(SQL_SELECT_KIT_FOR_NOTIFICATION_EXTERNAL_SHIPPER + SELECT_BY_RETURN_NUMBER, new String[] { RECEIVED, trackingId }, 2);//todo change this to the number of subkits but for now 2 for test boston works
+                        KitDDPNotification kitDDPNotification = KitDDPNotification.getKitDDPNotification(conn,SQL_SELECT_KIT_FOR_NOTIFICATION_EXTERNAL_SHIPPER + SELECT_BY_RETURN_NUMBER, new String[] { RECEIVED, trackingId }, 2);//todo change this to the number of subkits but for now 2 for test boston works
                         if (kitDDPNotification != null) {
                             logger.info("Triggering DDP for received kit with external order number: " + kit.getExternalOrderNumber());
                             EventUtil.triggerDDP(conn, kitDDPNotification);

--- a/src/main/java/org/broadinstitute/dsm/jobs/TestBostonUPSTrackingJob.java
+++ b/src/main/java/org/broadinstitute/dsm/jobs/TestBostonUPSTrackingJob.java
@@ -181,8 +181,7 @@ public class TestBostonUPSTrackingJob implements Job {
                                            DdpKit kit,
                                            Instant earliestInTransitTime) {
         String upsUpdate = statusType + " " + statusDescription;
-        SimpleResult result = inTransaction((conn) -> {
-            SimpleResult dbVals = new SimpleResult();
+        inTransaction((conn) -> {
             try (PreparedStatement stmt = conn.prepareStatement(query)) {
                 stmt.setString(1, upsUpdate);
                 stmt.setString(2, date);
@@ -191,56 +190,52 @@ public class TestBostonUPSTrackingJob implements Job {
                 if (r != 2) {//number of subkits
                     logger.error("Update query for UPS tracking updated " + r + " rows! with tracking/return id: " + trackingId);
                 }
+
+                if (!isReturn) {
+                    if (shouldTriggerEventForKitOnItsWayToParticipant(statusType, oldType)) {
+                        KitDDPNotification kitDDPNotification = KitDDPNotification.getKitDDPNotification(SQL_SELECT_KIT_FOR_NOTIFICATION_EXTERNAL_SHIPPER + SELECT_BY_TRACKING_NUMBER, new String[] { DELIVERED, trackingId }, 2);//todo change this to the number of subkits but for now 2 for test boston works
+                        if (kitDDPNotification != null) {
+                            logger.info("Triggering DDP for kit going to participant with external order number: " + kit.getExternalOrderNumber());
+                            EventUtil.triggerDDP(conn, kitDDPNotification);
+                        }
+                        else {
+                            logger.error("delivered kitDDPNotification was null for " + kit.getExternalOrderNumber());
+                        }
+                    }
+
+                }
+                else { // this is a return
+                    if (earliestInTransitTime != null && !kit.isCEOrdered()) {
+                        // if we have the first date of an inbound event, create an order in CE
+                        // using the earliest date of inbound event
+                        orderRegistrar.orderTest(DSMServer.careEvolveAuth, kit.getHRUID(), kit.getKitLabel(), kit.getExternalOrderNumber(), earliestInTransitTime);
+                        logger.info("Placed CE order for kit with external order number " + kit.getExternalOrderNumber());
+                        kit.changeCEOrdered(true);
+                    }
+                    else {
+                        logger.info("No return events for " + kit.getKitLabel() + ".  Will not place order yet.");
+                    }
+                    if (shouldTriggerEventForReturnKitDelivery(statusType, oldType)) {
+                        KitUtil.setKitReceived(kit.getKitLabel());
+                        logger.info("RECEIVED: " + trackingId);
+                        KitDDPNotification kitDDPNotification = KitDDPNotification.getKitDDPNotification(SQL_SELECT_KIT_FOR_NOTIFICATION_EXTERNAL_SHIPPER + SELECT_BY_RETURN_NUMBER, new String[] { RECEIVED, trackingId }, 2);//todo change this to the number of subkits but for now 2 for test boston works
+                        if (kitDDPNotification != null) {
+                            logger.info("Triggering DDP for received kit with external order number: " + kit.getExternalOrderNumber());
+                            EventUtil.triggerDDP(conn, kitDDPNotification);
+
+                        }
+                        else {
+                            logger.error("received kitDDPNotification was null for " + kit.getExternalOrderNumber());
+                        }
+                    }
+                }
+                logger.info("Updated status of tracking number " + trackingId + " to " + upsUpdate + " from " + oldType);
             }
             catch (Exception e) {
-                dbVals.resultException = e;
+                throw new RuntimeException("Could not update tracking info for tracking id " + trackingId, e);
             }
-            return dbVals;
+            return null;
         });
-        if (result.resultException != null) {
-            throw new RuntimeException(result.resultException);
-        }
-        else {
-            if (!isReturn) {
-                if (shouldTriggerEventForKitOnItsWayToParticipant(statusType, oldType)) {
-                    KitDDPNotification kitDDPNotification = KitDDPNotification.getKitDDPNotification(SQL_SELECT_KIT_FOR_NOTIFICATION_EXTERNAL_SHIPPER + SELECT_BY_TRACKING_NUMBER, new String[] { DELIVERED, trackingId }, 2);//todo change this to the number of subkits but for now 2 for test boston works
-                    if (kitDDPNotification != null) {
-                        logger.info("Triggering DDP for kit going to participant with external order number: " + kit.getExternalOrderNumber());
-                        EventUtil.triggerDDP(kitDDPNotification);
-                    }
-                    else {
-                        logger.error("delivered kitDDPNotification was null for " + kit.getExternalOrderNumber());
-                    }
-                }
-
-            }
-            else { // this is a return
-                if (earliestInTransitTime != null && !kit.isCEOrdered()) {
-                    // if we have the first date of an inbound event, create an order in CE
-                    // using the earliest date of inbound event
-                    orderRegistrar.orderTest(DSMServer.careEvolveAuth, kit.getHRUID(), kit.getKitLabel(), kit.getExternalOrderNumber(), earliestInTransitTime);
-                    logger.info("Placed CE order for kit with external order number " + kit.getExternalOrderNumber());
-                    kit.changeCEOrdered(true);
-                }
-                else {
-                    logger.info("No return events for " + kit.getKitLabel() + ".  Will not place order yet.");
-                }
-                if (shouldTriggerEventForReturnKitDelivery(statusType, oldType)) {
-                    KitUtil.setKitReceived(kit.getKitLabel());
-                    logger.info("RECEIVED: " + trackingId);
-                    KitDDPNotification kitDDPNotification = KitDDPNotification.getKitDDPNotification(SQL_SELECT_KIT_FOR_NOTIFICATION_EXTERNAL_SHIPPER + SELECT_BY_RETURN_NUMBER, new String[] { RECEIVED, trackingId }, 2);//todo change this to the number of subkits but for now 2 for test boston works
-                    if (kitDDPNotification != null) {
-                        logger.info("Triggering DDP for received kit with external order number: " + kit.getExternalOrderNumber());
-                        EventUtil.triggerDDP(kitDDPNotification);
-
-                    }
-                    else {
-                        logger.error("received kitDDPNotification was null for " + kit.getExternalOrderNumber());
-                    }
-                }
-            }
-            logger.info("Updated status of tracking number " + trackingId + " to " + upsUpdate + " from " + oldType);
-        }
     }
 
     /**

--- a/src/main/java/org/broadinstitute/dsm/model/KitRequestExternal.java
+++ b/src/main/java/org/broadinstitute/dsm/model/KitRequestExternal.java
@@ -1,10 +1,12 @@
 package org.broadinstitute.dsm.model;
 
+import lombok.NonNull;
 import org.broadinstitute.ddp.db.SimpleResult;
 import org.broadinstitute.dsm.model.ddp.DDPParticipant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 
 import static org.broadinstitute.ddp.db.TransactionWrapper.inTransaction;
@@ -53,55 +55,39 @@ public class KitRequestExternal extends KitRequest {
     }
 
     // update kit request with response of external shipper
-    public static void updateKitRequestResponse(String externalResponse, String dsmKitRequestId) {
-        SimpleResult results = inTransaction((conn) -> {
-            SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement stmt = conn.prepareStatement(SQL_UPDATE_KIT_REQUEST_EXTERNAL_SHIPPER_RESPONSE)) {
-                stmt.setString(1, externalResponse);
-                stmt.setString(2, dsmKitRequestId);
+    public static void updateKitRequestResponse(@NonNull Connection conn, String externalResponse, String dsmKitRequestId) {
+        try (PreparedStatement stmt = conn.prepareStatement(SQL_UPDATE_KIT_REQUEST_EXTERNAL_SHIPPER_RESPONSE)) {
+            stmt.setString(1, externalResponse);
+            stmt.setString(2, dsmKitRequestId);
 
-                int result = stmt.executeUpdate();
-                if (result > 1) {
-                    throw new RuntimeException("Error updating kit request w/ dsm_kit_request_id " + dsmKitRequestId + " it was updating " + result + " rows");
-                }
+            int result = stmt.executeUpdate();
+            if (result > 1) {
+                throw new RuntimeException("Error updating kit request w/ dsm_kit_request_id " + dsmKitRequestId + " it was updating " + result + " rows");
             }
-            catch (Exception e) {
-                dbVals.resultException = e;
-            }
-            return dbVals;
-        });
-
-        if (results.resultException != null) {
-            logger.error("Error updating kit request w/ dsm_kit_request_id " + dsmKitRequestId, results.resultException);
+        }
+        catch (Exception e) {
+            logger.error("Error updating kit request w/ dsm_kit_request_id " + dsmKitRequestId, e);
         }
     }
 
     // update kit request with response of external shipper
-    public static void updateKitRequestResponse(String trackingIdTo, String trackingIdReturn, String kitLabel, long sentDate,
+    public static void updateKitRequestResponse(@NonNull Connection conn, String trackingIdTo, String trackingIdReturn, String kitLabel, long sentDate,
                                                 String sentBy, String dsmKitRequestId) {
-        SimpleResult results = inTransaction((conn) -> {
-            SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement stmt = conn.prepareStatement(SQL_UPDATE_KIT_EXTERNAL_SHIPPER)) {
-                stmt.setString(1, trackingIdTo);
-                stmt.setString(2, trackingIdReturn);
-                stmt.setString(3, kitLabel);
-                stmt.setLong(4, sentDate);
-                stmt.setString(5, sentBy);
-                stmt.setString(6, dsmKitRequestId);
+        try (PreparedStatement stmt = conn.prepareStatement(SQL_UPDATE_KIT_EXTERNAL_SHIPPER)) {
+            stmt.setString(1, trackingIdTo);
+            stmt.setString(2, trackingIdReturn);
+            stmt.setString(3, kitLabel);
+            stmt.setLong(4, sentDate);
+            stmt.setString(5, sentBy);
+            stmt.setString(6, dsmKitRequestId);
 
-                int result = stmt.executeUpdate();
-                if (result != 1) {
-                    throw new RuntimeException("Error updating kit w/ dsm_kit_request_id " + dsmKitRequestId + " it was updating " + result + " rows");
-                }
+            int result = stmt.executeUpdate();
+            if (result != 1) {
+                throw new RuntimeException("Error updating kit w/ dsm_kit_request_id " + dsmKitRequestId + " it was updating " + result + " rows");
             }
-            catch (Exception e) {
-                dbVals.resultException = e;
-            }
-            return dbVals;
-        });
-
-        if (results.resultException != null) {
-            logger.error("Error updating kit w/ dsm_kit_request_id " + dsmKitRequestId, results.resultException);
+        }
+        catch (Exception e) {
+            logger.error("Error updating kit w/ dsm_kit_request_id " + dsmKitRequestId, e);
         }
     }
 }

--- a/src/main/java/org/broadinstitute/dsm/model/KitRequestExternal.java
+++ b/src/main/java/org/broadinstitute/dsm/model/KitRequestExternal.java
@@ -29,28 +29,20 @@ public class KitRequestExternal extends KitRequest {
     }
 
     // update kit request with status and date of external shipper
-    public static void updateKitRequest(String externalOrderStatus, long externalOrderDate, String dsmKitRequestId) {
-        SimpleResult results = inTransaction((conn) -> {
-            SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement stmt = conn.prepareStatement(SQL_UPDATE_KIT_REQUEST_EXTERNAL_SHIPPER_STATUS)) {
-                stmt.setString(1, externalOrderStatus);
-                stmt.setLong(2, externalOrderDate);
-                stmt.setString(3, dsmKitRequestId);
-                stmt.setString(4, externalOrderStatus);
+    public static void updateKitRequest(Connection conn, String externalOrderStatus, long externalOrderDate, String dsmKitRequestId) {
+        try (PreparedStatement stmt = conn.prepareStatement(SQL_UPDATE_KIT_REQUEST_EXTERNAL_SHIPPER_STATUS)) {
+            stmt.setString(1, externalOrderStatus);
+            stmt.setLong(2, externalOrderDate);
+            stmt.setString(3, dsmKitRequestId);
+            stmt.setString(4, externalOrderStatus);
 
-                int result = stmt.executeUpdate();
-                if (result > 1) {
-                    throw new RuntimeException("Error updating kit request w/ dsm_kit_request_id " + dsmKitRequestId + " it was updating " + result + " rows");
-                }
+            int result = stmt.executeUpdate();
+            if (result > 1) {
+                throw new RuntimeException("Error updating kit request w/ dsm_kit_request_id " + dsmKitRequestId + " it was updating " + result + " rows");
             }
-            catch (Exception e) {
-                dbVals.resultException = e;
-            }
-            return dbVals;
-        });
-
-        if (results.resultException != null) {
-            logger.error("Error updating kit request w/ dsm_kit_request_id " + dsmKitRequestId, results.resultException);
+        }
+        catch (Exception e) {
+           throw new RuntimeException("Error updating kit request w/ dsm_kit_request_id " + dsmKitRequestId, e);
         }
     }
 

--- a/src/main/java/org/broadinstitute/dsm/model/ParticipantWrapper.java
+++ b/src/main/java/org/broadinstitute/dsm/model/ParticipantWrapper.java
@@ -53,9 +53,17 @@ public class ParticipantWrapper {
         if (filters == null) {
             Map<String, Map<String, Object>> participantESData = getESData(instance);
             Map<String, Participant> participants = Participant.getParticipants(instance.getName());
-            Map<String, List<MedicalRecord>> medicalRecords = MedicalRecord.getMedicalRecords(instance.getName());
-            Map<String, List<OncHistoryDetail>> oncHistoryDetails = OncHistoryDetail.getOncHistoryDetails(instance.getName());
-            Map<String, List<KitRequestShipping>> kitRequests = KitRequestShipping.getKitRequests(instance.getName());
+            Map<String, List<MedicalRecord>> medicalRecords = null;
+            Map<String, List<OncHistoryDetail>> oncHistoryDetails = null;
+            Map<String, List<KitRequestShipping>> kitRequests = null;
+
+            if (instance.isHasRole()) { //only needed if study has mr&tissue tracking
+                medicalRecords = MedicalRecord.getMedicalRecords(instance.getName());
+                oncHistoryDetails = OncHistoryDetail.getOncHistoryDetails(instance.getName());
+            }
+            if (DDPInstance.getRole(instance.getName(), DBConstants.KIT_REQUEST_ACTIVATED)) { //only needed if study is shipping samples per DSM
+                kitRequests = KitRequestShipping.getKitRequests(instance);
+            }
             Map<String, List<AbstractionActivity>> abstractionActivities = AbstractionActivity.getAllAbstractionActivityByRealm(instance.getName());
             Map<String, List<AbstractionGroup>> abstractionSummary = AbstractionFinal.getAbstractionFinal(instance.getName());
 
@@ -97,7 +105,7 @@ public class ParticipantWrapper {
                         baseList = getCommonEntries(baseList, new ArrayList<>(oncHistories.keySet()));
                     }
                     else if (DBConstants.DDP_KIT_REQUEST_ALIAS.equals(source)) {
-                        kitRequests = KitRequestShipping.getKitRequests(instance.getName(), filters.get(source));
+                        kitRequests = KitRequestShipping.getKitRequests(instance, filters.get(source));
                         baseList = getCommonEntries(baseList, new ArrayList<>(kitRequests.keySet()));
                     }
                     else if (DBConstants.DDP_ABSTRACTION_ALIAS.equals(source)) {
@@ -121,14 +129,14 @@ public class ParticipantWrapper {
             if (participants == null) {
                 participants = Participant.getParticipants(instance.getName());
             }
-            if (medicalRecords == null) {
+            if (medicalRecords == null && instance.isHasRole()) {
                 medicalRecords = MedicalRecord.getMedicalRecords(instance.getName());
             }
-            if (oncHistories == null) {
+            if (oncHistories == null && instance.isHasRole()) {
                 oncHistories = OncHistoryDetail.getOncHistoryDetails(instance.getName());
             }
-            if (kitRequests == null) {
-                kitRequests = KitRequestShipping.getKitRequests(instance.getName());
+            if (kitRequests == null && DDPInstance.getRole(instance.getName(), DBConstants.KIT_REQUEST_ACTIVATED)) { //only needed if study is shipping samples per DSM
+                kitRequests = KitRequestShipping.getKitRequests(instance);
             }
             if (abstractionActivities == null) {
                 abstractionActivities = AbstractionActivity.getAllAbstractionActivityByRealm(instance.getName());

--- a/src/main/java/org/broadinstitute/dsm/route/BSPKitQueryRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/BSPKitQueryRoute.java
@@ -22,6 +22,7 @@ import spark.Request;
 import spark.Response;
 import spark.Route;
 
+import java.sql.Connection;
 import java.util.*;
 
 public class BSPKitQueryRoute implements Route {
@@ -40,10 +41,13 @@ public class BSPKitQueryRoute implements Route {
         if (StringUtils.isBlank(kitLabel)) {
             throw new RuntimeException("Please include a kit label as a path parameter");
         }
-        return getBSPKitInfo(kitLabel, response);
+
+        return TransactionWrapper.inTransaction(conn -> {
+            return getBSPKitInfo(conn, kitLabel, response);
+        });
     }
 
-    public Object getBSPKitInfo(@NonNull String kitLabel, @NonNull Response response) {
+    public Object getBSPKitInfo(Connection conn, @NonNull String kitLabel, @NonNull Response response) {
         logger.info("Checking label " + kitLabel);
         BSPKitQueryResult bspKitInfo = BSPKitQueryResult.getBSPKitQueryResult(kitLabel);
 
@@ -95,12 +99,12 @@ public class BSPKitQueryRoute implements Route {
                         }
                     }
                     else {
-                        triggerDDP(bspKitInfo, firstTimeReceived, kitLabel);
+                        triggerDDP(conn, bspKitInfo, firstTimeReceived, kitLabel);
                     }
                 }
             }
             else {
-                triggerDDP(bspKitInfo, firstTimeReceived, kitLabel);
+                triggerDDP(conn, bspKitInfo, firstTimeReceived, kitLabel);
             }
 
             String bspParticipantId = bspKitInfo.getBspParticipantId();
@@ -129,12 +133,12 @@ public class BSPKitQueryRoute implements Route {
         }
     }
 
-    private void triggerDDP(@NonNull BSPKitQueryResult bspKitInfo, boolean firstTimeReceived, String kitLabel) {
+    private void triggerDDP(Connection conn, @NonNull BSPKitQueryResult bspKitInfo, boolean firstTimeReceived, String kitLabel) {
         try {
             if (bspKitInfo.isHasParticipantNotifications() && firstTimeReceived) {
                 KitDDPNotification kitDDPNotification = KitDDPNotification.getKitDDPNotification(TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.GET_RECEIVED_KIT_INFORMATION_FOR_NOTIFICATION_EMAIL), kitLabel, 1);
                 if (kitDDPNotification != null) {
-                    EventUtil.triggerDDP(kitDDPNotification);
+                    EventUtil.triggerDDP(conn, kitDDPNotification);
                 }
             }
         }

--- a/src/main/java/org/broadinstitute/dsm/route/BSPKitQueryRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/BSPKitQueryRoute.java
@@ -57,7 +57,7 @@ public class BSPKitQueryRoute implements Route {
             return null;
         }
 
-        boolean firstTimeReceived = KitUtil.setKitReceived(kitLabel);
+        boolean firstTimeReceived = KitUtil.setKitReceived(conn, kitLabel);
         if (StringUtils.isNotBlank(bspKitInfo.getParticipantExitId())) {
             String message = "Kit of exited participant " + bspKitInfo.getBspParticipantId() + " was received by GP.<br>";
             notificationUtil.sentNotification(bspKitInfo.getNotificationRecipient(), message, NotificationUtil.DSM_SUBJECT);

--- a/src/main/java/org/broadinstitute/dsm/route/DashboardRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/DashboardRoute.java
@@ -214,7 +214,7 @@ public class DashboardRoute extends RequestHandler {
      * @return DashboardInformation
      */
     public DashboardInformation getMedicalRecordDashboard(@NonNull long start, @NonNull long end, @NonNull String realm) {
-        DDPInstance ddpInstance = DDPInstance.getDDPInstanceWithRole(realm, DBConstants.HAS_MEDICAL_RECORD_INFORMATION_IN_DB);
+        DDPInstance ddpInstance = DDPInstance.getDDPInstanceWithRole(realm, DBConstants.MEDICAL_RECORD_ACTIVATED);
 
         Map<String, Map<String, Object>> participantESData = ParticipantWrapper.getESData(ddpInstance);
         Map<String, Participant> participants = Participant.getParticipants(realm);

--- a/src/main/java/org/broadinstitute/dsm/route/FilterRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/FilterRoute.java
@@ -54,7 +54,7 @@ public class FilterRoute extends RequestHandler {
         DDPInstance instance = null;
         if (queryParams.value(RoutePath.REALM) != null) {
             realm = queryParams.get(RoutePath.REALM).value();
-            instance = DDPInstance.getDDPInstanceWithRole(realm, DBConstants.HAS_MEDICAL_RECORD_INFORMATION_IN_DB);
+            instance = DDPInstance.getDDPInstanceWithRole(realm, DBConstants.MEDICAL_RECORD_ACTIVATED);
         }
         else {
             throw new RuntimeException("No realm is sent!");
@@ -330,7 +330,7 @@ public class FilterRoute extends RequestHandler {
 
     public static List<?> getListBasedOnFilterName(String filterName, String realm, String parent, String queryString, Map<String, String> filters) {
         if (TISSUE_LIST_PARENT.equals(parent)) {
-            DDPInstance instance = DDPInstance.getDDPInstanceWithRole(realm, DBConstants.HAS_MEDICAL_RECORD_INFORMATION_IN_DB);
+            DDPInstance instance = DDPInstance.getDDPInstanceWithRole(realm, DBConstants.MEDICAL_RECORD_ACTIVATED);
             String subQueryForFiltering = "";
             if (StringUtils.isNotBlank(filterName)) {
                 if (filterName.equals(ViewFilter.DESTROYING_FILTERS)) {

--- a/src/main/java/org/broadinstitute/dsm/route/KitStatusChangeRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/KitStatusChangeRoute.java
@@ -138,7 +138,7 @@ public class KitStatusChangeRoute extends RequestHandler {
                         logger.info("Updated kitRequests w/ ddp_label " + kit);
                         KitDDPNotification kitDDPNotification = KitDDPNotification.getKitDDPNotification(TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.GET_SENT_KIT_INFORMATION_FOR_NOTIFICATION_EMAIL), kit, 1);
                         if (kitDDPNotification != null) {
-                            EventUtil.triggerDDP(kitDDPNotification);
+                            EventUtil.triggerDDP(conn, kitDDPNotification);
                         }
                     }
                     else if (RoutePath.TRACKING_SCAN_REQUEST.equals(changeType)) {

--- a/src/main/java/org/broadinstitute/dsm/statics/QueryExtension.java
+++ b/src/main/java/org/broadinstitute/dsm/statics/QueryExtension.java
@@ -42,5 +42,7 @@ public class QueryExtension {
     public static final String DISCARD_KIT_BY_DISCARD_ID = " and kit_discard_id = ?";
 
     public static final String WHERE_INSTANCE_ID = " where ddp_instance_id = ?";
+    public static final String WHERE_REALM_INSTANCE_ID = " where realm.ddp_instance_id = ?";
+
 
 }

--- a/src/main/java/org/broadinstitute/dsm/util/DDPKitRequest.java
+++ b/src/main/java/org/broadinstitute/dsm/util/DDPKitRequest.java
@@ -56,13 +56,13 @@ public class DDPKitRequest {
                     KitDetail[] kitDetails = DDPRequestUtil.getResponseObject(KitDetail[].class, dsmRequest, latestKit.getInstanceName(), latestKit.isHasAuth0Token());
                     if (kitDetails != null) {
                         logger.info("Got " + kitDetails.length + " 'new' KitRequests from " + latestKit.getInstanceName());
-                        Map<String, Map<String, Object>> participantsESData = null;
+//                        Map<String, Map<String, Object>> participantsESData = null;
                         if (kitDetails.length > 0) {
 
-                            if (StringUtils.isNotBlank(latestKit.getParticipantIndexES())) {
-                                //could be filtered as well to have a smaller list
-                                participantsESData = ElasticSearchUtil.getDDPParticipantsFromES(latestKit.getInstanceName(), latestKit.getParticipantIndexES());
-                            }
+//                            if (StringUtils.isNotBlank(latestKit.getParticipantIndexES())) {
+//                                //could be filtered as well to have a smaller list
+//                                participantsESData = ElasticSearchUtil.getDDPParticipantsFromES(latestKit.getInstanceName(), latestKit.getParticipantIndexES());
+//                            }
 
                             Map<String, KitType> kitTypes = KitType.getKitLookup();
                             Map<Integer, KitRequestSettings> kitRequestSettingsMap = KitRequestSettings.getKitRequestSettings(latestKit.getInstanceID());
@@ -90,6 +90,8 @@ public class DDPKitRequest {
                                             //kit requests from study-server
                                             if (StringUtils.isNotBlank(latestKit.getParticipantIndexES())) {
                                                 //without order list, that was only added for promise and currently is not used!
+                                                DDPInstance ddpInstance = DDPInstance.getDDPInstance(latestKit.getInstanceName());
+                                                Map<String, Map<String, Object>> participantsESData = ElasticSearchUtil.getFilteredDDPParticipantsFromES(ddpInstance, ElasticSearchUtil.BY_GUID + kitDetail.getParticipantId());
                                                 if (participantsESData != null && !participantsESData.isEmpty()) {
                                                     Map<String, Object> participantESData = participantsESData.get(kitDetail.getParticipantId());
                                                     if (participantESData != null && !participantESData.isEmpty()) {

--- a/src/main/java/org/broadinstitute/dsm/util/EventUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/EventUtil.java
@@ -2,6 +2,7 @@ package org.broadinstitute.dsm.util;
 
 import lombok.NonNull;
 import org.broadinstitute.ddp.db.SimpleResult;
+import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.dsm.db.ParticipantEvent;
 import org.broadinstitute.dsm.model.KitDDPNotification;
 import org.broadinstitute.dsm.model.TestResultEvent;
@@ -14,6 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -43,7 +45,10 @@ public class EventUtil {
         Collection<KitDDPNotification> kitDDPNotifications = getKitsNotReceived();
         for (KitDDPNotification kitInfo : kitDDPNotifications) {
             if (KitDDPNotification.REMINDER.equals(kitInfo.getEventType())) {
-                triggerDDP(kitInfo);
+                TransactionWrapper.inTransaction(conn -> {
+                    triggerDDP(conn, kitInfo);
+                    return null;
+                });
             }
         }
     }
@@ -83,85 +88,77 @@ public class EventUtil {
         return kitDDPNotifications;
     }
 
-    public static void triggerDDP(@NonNull KitDDPNotification kitDDPNotification) {
+    public static void triggerDDP(Connection conn,@NonNull KitDDPNotification kitDDPNotification) {
         Collection<String> events = ParticipantEvent.getParticipantEvent(kitDDPNotification.getParticipantId(), kitDDPNotification.getDdpInstanceId());
         if (!events.contains(kitDDPNotification.getEventName())) {
-            EventUtil.triggerDDP(kitDDPNotification.getEventName(), kitDDPNotification);
+            EventUtil.triggerDDP(conn, kitDDPNotification.getEventName(), kitDDPNotification);
         }
         else {
             logger.info("Participant direct event was added in the participant_event table. DDP will not get triggered");
             //to add these events also to the event table, but without triggering the ddp and flag EVENT_TRIGGERED = false
-            addEvent(kitDDPNotification.getEventName(), kitDDPNotification.getDdpInstanceId(), kitDDPNotification.getDsmKitRequestId(), false);
+            addEvent(conn, kitDDPNotification.getEventName(), kitDDPNotification.getDdpInstanceId(), kitDDPNotification.getDsmKitRequestId(), false);
         }
     }
 
-    public static void triggerDDPWithTestResult(@NonNull KitDDPNotification kitDDPNotification, @Nonnull TestBostonResult result) {
+    public static void triggerDDPWithTestResult(Connection conn,@NonNull KitDDPNotification kitDDPNotification, @Nonnull TestBostonResult result) {
         Collection<String> events = ParticipantEvent.getParticipantEvent(kitDDPNotification.getParticipantId(), kitDDPNotification.getDdpInstanceId());
         if (!events.contains(kitDDPNotification.getEventName())) {
-            EventUtil.triggerDDPWithTestResult(kitDDPNotification.getEventName(), kitDDPNotification, result);
+            EventUtil.triggerDDPWithTestResult(conn, kitDDPNotification.getEventName(), kitDDPNotification, result);
         }
         else {
             logger.info("Participant direct event was added in the participant_event table. DDP will not get triggered");
             //to add these events also to the event table, but without triggering the ddp and flag EVENT_TRIGGERED = false
-            addEvent(kitDDPNotification.getEventName(), kitDDPNotification.getDdpInstanceId(), kitDDPNotification.getDsmKitRequestId(), false);
+            addEvent(conn, kitDDPNotification.getEventName(), kitDDPNotification.getDdpInstanceId(), kitDDPNotification.getDsmKitRequestId(), false);
         }
     }
 
-    private static void triggerDDP(@NonNull String eventType, @NonNull KitDDPNotification kitInfo) {
+    private static void triggerDDP(Connection conn, @NonNull String eventType, @NonNull KitDDPNotification kitInfo) {
         try {
             KitEvent event = new KitEvent(kitInfo.getParticipantId(), eventType, kitInfo.getDate() / 1000, kitInfo.getUploadReason(), kitInfo.getDdpKitRequestId());
             String sendRequest = kitInfo.getBaseUrl() + RoutePath.DDP_PARTICIPANT_EVENT_PATH + "/" + kitInfo.getParticipantId();
             DDPRequestUtil.postRequest(sendRequest, event, kitInfo.getInstanceName(), kitInfo.isHasAuth0Token());
-            addEvent(eventType, kitInfo.getDdpInstanceId(), kitInfo.getDsmKitRequestId());
+            addEvent(conn, eventType, kitInfo.getDdpInstanceId(), kitInfo.getDsmKitRequestId());
         }
         catch (IOException e) {
             logger.error("Failed to trigger DDP to notify participant about " + eventType);
             //to add these events also to the event table, but without triggering the ddp and flag EVENT_TRIGGERED = false
-            addEvent(eventType, kitInfo.getDdpInstanceId(), kitInfo.getDsmKitRequestId(), false);
+            addEvent(conn, eventType, kitInfo.getDdpInstanceId(), kitInfo.getDsmKitRequestId(), false);
         }
     }
 
-    private static void triggerDDPWithTestResult(@NonNull String eventType, @NonNull KitDDPNotification kitInfo, @Nonnull TestBostonResult result) {
+    private static void triggerDDPWithTestResult(Connection conn,@NonNull String eventType, @NonNull KitDDPNotification kitInfo, @Nonnull TestBostonResult result) {
         try {
             DSMTestResult dsmTestResult = new DSMTestResult(result.getResult(), result.getTimeCompleted(), result.isCorrected());
             TestResultEvent event = new TestResultEvent(kitInfo.getParticipantId(), eventType, kitInfo.getDate() / 1000,kitInfo.getUploadReason(), kitInfo.getDdpKitRequestId(),  dsmTestResult);
             String sendRequest = kitInfo.getBaseUrl() + RoutePath.DDP_PARTICIPANT_EVENT_PATH + "/" + kitInfo.getParticipantId();
             DDPRequestUtil.postRequest(sendRequest, event, kitInfo.getInstanceName(), kitInfo.isHasAuth0Token());
-            addEvent(eventType, kitInfo.getDdpInstanceId(), kitInfo.getDsmKitRequestId());
+            addEvent(conn, eventType, kitInfo.getDdpInstanceId(), kitInfo.getDsmKitRequestId());
         }
         catch (IOException e) {
             logger.error("Failed to trigger DDP to notify participant about " + eventType);
             //to add these events also to the event table, but without triggering the ddp and flag EVENT_TRIGGERED = false
-            addEvent(eventType, kitInfo.getDdpInstanceId(), kitInfo.getDsmKitRequestId(), false);
+            addEvent(conn, eventType, kitInfo.getDdpInstanceId(), kitInfo.getDsmKitRequestId(), false);
         }
     }
 
-    private static void addEvent(@NonNull String type, @NonNull String instanceID, @NonNull String requestId) {
-        addEvent(type, instanceID, requestId, true);
+    private static void addEvent(Connection conn, @NonNull String type, @NonNull String instanceID, @NonNull String requestId) {
+        addEvent(conn, type, instanceID, requestId, true);
     }
 
-    public static void addEvent(@NonNull String type, @NonNull String instanceID, @NonNull String requestId, boolean trigger) {
-        SimpleResult results = inTransaction((conn) -> {
-            SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement stmt = conn.prepareStatement(SQL_INSERT_EVENT)) {
-                stmt.setLong(1, System.currentTimeMillis());
-                stmt.setString(2, type);
-                stmt.setString(3, instanceID);
-                stmt.setString(4, requestId);
-                stmt.setBoolean(5, trigger);
-                int result = stmt.executeUpdate();
-                if (result != 1) {
-                    throw new RuntimeException("Error could not add event for kit request " + requestId);
-                }
+    public static void addEvent(Connection conn, @NonNull String type, @NonNull String instanceID, @NonNull String requestId, boolean trigger) {
+        try (PreparedStatement stmt = conn.prepareStatement(SQL_INSERT_EVENT)) {
+            stmt.setLong(1, System.currentTimeMillis());
+            stmt.setString(2, type);
+            stmt.setString(3, instanceID);
+            stmt.setString(4, requestId);
+            stmt.setBoolean(5, trigger);
+            int result = stmt.executeUpdate();
+            if (result != 1) {
+                throw new RuntimeException("Error could not add event for kit request " + requestId);
             }
-            catch (SQLException e) {
-                dbVals.resultException = e;
-            }
-            return dbVals;
-        });
-
-        if (results.resultException != null) {
-            logger.error("Error inserting event ", results.resultException);
+        }
+        catch (SQLException e) {
+            logger.error("Error inserting event ", e);
         }
     }
 }

--- a/src/main/java/org/broadinstitute/dsm/util/KitUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/KitUtil.java
@@ -348,34 +348,27 @@ public class KitUtil {
         }
     }
 
-    public static boolean setKitReceived(String kitLabel) {
-        SimpleResult results = inTransaction((conn) -> {
-            SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement stmt = conn.prepareStatement(SQL_UPDATE_KIT_RECEIVED)) {
-                stmt.setLong(1, System.currentTimeMillis());
-                stmt.setString(2, BSP);
-                stmt.setString(3, kitLabel);
-                int result = stmt.executeUpdate();
-                if (result > 1) { // 1 row or 0 row updated is perfect
-                    throw new RuntimeException("Error updating kit w/label " + kitLabel + " (was updating " + result + " rows)");
-                }
-                if (result == 1) {
-                    dbVals.resultValue = true;
-                }
-                else {
-                    dbVals.resultValue = false;
-                }
+    public static boolean setKitReceived(Connection conn, String kitLabel) {
+        boolean resultBoolean = false;
+        try (PreparedStatement stmt = conn.prepareStatement(SQL_UPDATE_KIT_RECEIVED)) {
+            stmt.setLong(1, System.currentTimeMillis());
+            stmt.setString(2, BSP);
+            stmt.setString(3, kitLabel);
+            int result = stmt.executeUpdate();
+            if (result > 1) { // 1 row or 0 row updated is perfect
+                throw new RuntimeException("Error updating kit w/label " + kitLabel + " (was updating " + result + " rows)");
             }
-            catch (Exception ex) {
-                dbVals.resultException = ex;
+            if (result == 1) {
+                resultBoolean = true;
             }
-            return dbVals;
-        });
-        if (results.resultException != null) {
-            logger.error("Failed to set kit w/ label " + kitLabel + " as received ", results.resultException);
-            return false;
+            else {
+                resultBoolean = false;
+            }
         }
-        return (boolean) results.resultValue;
+        catch (Exception e) {
+            logger.error("Failed to set kit w/ label " + kitLabel + " as received ", e);
+        }
+        return resultBoolean;
     }
 
     public static void getKitStatus() {

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/ExternalShipper.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/ExternalShipper.java
@@ -18,6 +18,6 @@ public interface ExternalShipper {
 
     public void orderCancellation(ArrayList<KitRequest> kitRequests) throws Exception;
 
-    public ArrayList<KitRequest> getKitRequestsNotDone(int instanceId);
+    public  ArrayList<KitRequest> getKitRequestsNotDone(int instanceId);
 
 }

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/ExternalShipper.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/ExternalShipper.java
@@ -14,7 +14,7 @@ public interface ExternalShipper {
 
     public void orderStatus(ArrayList<KitRequest> kitRequests) throws Exception;
 
-    public void orderConfirmation(ArrayList<KitRequest> kitRequests, long startDate, long endDate) throws Exception;
+    public void orderConfirmation(long startDate, long endDate) throws Exception;
 
     public void orderCancellation(ArrayList<KitRequest> kitRequests) throws Exception;
 

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/ExternalShipper.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/ExternalShipper.java
@@ -12,12 +12,14 @@ public interface ExternalShipper {
 
     public void orderKitRequests(ArrayList<KitRequest> kitRequests, EasyPostUtil easyPostUtil, KitRequestSettings kitRequestSettings, String shippingCarrier) throws Exception;
 
-    public void orderStatus(ArrayList<KitRequest> kitRequests) throws Exception;
+    /**
+     * Checks for incomplete orders and updates the internal status
+     * of the order
+     */
+    void updateOrderStatusForPendingKitRequests(int instanceId);
 
     public void orderConfirmation(long startDate, long endDate) throws Exception;
 
     public void orderCancellation(ArrayList<KitRequest> kitRequests) throws Exception;
-
-    public  ArrayList<KitRequest> getKitRequestsNotDone(int instanceId);
 
 }

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
@@ -57,8 +57,8 @@ public class GBFRequestUtil implements ExternalShipper {
             "                        req.kit_type_id, req.external_order_status, req.external_order_number, req.external_order_date, req.external_response, kt.no_return, req.created_by, kit.kit_label FROM kit_type kt, ddp_kit_request req, ddp_kit kit, ddp_instance ddp_site\n" +
             "                        WHERE req.ddp_instance_id = ddp_site.ddp_instance_id AND req.kit_type_id = kt.kit_type_id AND kit.dsm_kit_request_id = req.dsm_kit_request_id\n" +
             "                        and kit.test_result is null and kit.CE_order is null\n" +
-            "                        and not (kit.ups_tracking_status is not null\n" +
-            "                                and kit.ups_return_status is not null)\n" +
+            "                        and (kit.ups_tracking_status is null\n" +
+            "                             or kit.ups_return_status is null)\n" +
             "                        ) AS request\n" +
             "                        LEFT JOIN ddp_participant_exit ex ON (ex.ddp_instance_id = request.ddp_instance_id AND ex.ddp_participant_id = request.ddp_participant_id)\n" +
             "                        LEFT JOIN (SELECT subK.kit_type_id, subK.external_name from ddp_kit_request_settings dkc\n" +

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
@@ -63,8 +63,7 @@ public class GBFRequestUtil implements ExternalShipper {
             "            LEFT JOIN ddp_participant_exit ex ON (ex.ddp_instance_id = request.ddp_instance_id AND ex.ddp_participant_id = request.ddp_participant_id) " +
             "            LEFT JOIN (SELECT subK.kit_type_id, subK.external_name from ddp_kit_request_settings dkc " +
             "            LEFT JOIN sub_kits_settings subK ON (subK.ddp_kit_request_settings_id = dkc.ddp_kit_request_settings_id)) as subkits ON (subkits.kit_type_id = request.kit_type_id) " +
-            "            WHERE ex.ddp_participant_exit_id is null AND request.ddp_instance_id = ? AND NOT external_order_status <=> 'CANCELLED' AND external_order_number IS NOT NULL " +
-            "            AND kit.kit_complete is null";
+            "            WHERE ex.ddp_participant_exit_id is null AND request.ddp_instance_id = ? AND NOT external_order_status <=> 'CANCELLED' AND external_order_number IS NOT NULL " ;
 
     private static final String SQL_SELECT_KIT_REQUEST_BY_EXTERNAL_ORDER_NUMBER = "SELECT dsm_kit_request_id FROM ddp_kit_request req WHERE external_order_number = ?";
     private static final String SQL_SELECT_SENT_KIT_FOR_NOTIFICATION_EXTERNAL_SHIPPER = "select  eve.*,   request.ddp_participant_id,   request.ddp_label, request.upload_reason, request.ddp_kit_request_id, request.dsm_kit_request_id, realm.ddp_instance_id, realm.instance_name, realm.base_url, realm.auth0_token, realm.notification_recipients, realm.migrated_ddp, kit.receive_date, kit.scan_date" +

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
@@ -300,8 +300,7 @@ public class GBFRequestUtil implements ExternalShipper {
             else {
                 logger.error("No kit requests found for kit with order number: " + confirmation.getOrderNumber());
             }
-        }
-        else {
+        } else {
             logger.error("No items for order " + confirmation.getOrderNumber());
         }
     }
@@ -324,8 +323,7 @@ public class GBFRequestUtil implements ExternalShipper {
                     for (ShippingConfirmation confirmation : confirmationList) {
                         try {
                             processingSingleConfirmation(gbfResponse, kitRequests, confirmation);
-                        }
-                        catch (Exception e) {
+                        } catch (Exception e) {
                             logger.error("Could not process confirmation for " + confirmation.getOrderNumber(), e);
                         }
                     }
@@ -507,7 +505,7 @@ public class GBFRequestUtil implements ExternalShipper {
         return xmlOutput.getWriter().toString();
     }
 
-    public static Map getParticipant(String realm) {
+    public static Map getParticipants(String realm) {
         DDPInstance ddpInstance = DDPInstance.getDDPInstanceWithRole(realm, DBConstants.NEEDS_NAME_LABELS);
         Map<String, Map<String, Object>> participantsESData = null;
         if (StringUtils.isNotBlank(ddpInstance.getParticipantIndexES())) {

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
@@ -52,20 +52,19 @@ public class GBFRequestUtil implements ExternalShipper {
 
     private static final Logger logger = LoggerFactory.getLogger(GBFRequestUtil.class);
 
-    public static final String SQL_SELECT_EXTERNAL_KIT_NOT_DONE = "SELECT * FROM (SELECT kt.kit_type_name, ddp_site.instance_name, ddp_site.ddp_instance_id, ddp_site.base_url, ddp_site.auth0_token, ddp_site.migrated_ddp, " +
-            "            ddp_site.collaborator_id_prefix, req.bsp_collaborator_sample_id, req.ddp_participant_id, req.ddp_label, req.dsm_kit_request_id, req.bsp_collaborator_participant_id, " +
-            "            req.kit_type_id, req.external_order_status, req.external_order_number, req.external_order_date, req.external_response, kt.no_return, req.created_by, kit.kit_label FROM kit_type kt, ddp_kit_request req, ddp_kit kit, ddp_instance ddp_site " +
-            "            WHERE req.ddp_instance_id = ddp_site.ddp_instance_id AND req.kit_type_id = kt.kit_type_id AND kit.dsm_kit_request_id = req.dsm_kit_request_id " +
-            "            and kit.test_result is null " +
-            "            and not (kit.ups_tracking_status like 'D%' " +
-            "                    and kit.ups_return_status like 'D%' " +
-            "                    and kit.ups_tracking_status is not null " +
-            "                    and kit.ups_return_status is not null) " +
-            "            ) AS request " +
-            "            LEFT JOIN ddp_participant_exit ex ON (ex.ddp_instance_id = request.ddp_instance_id AND ex.ddp_participant_id = request.ddp_participant_id) " +
-            "            LEFT JOIN (SELECT subK.kit_type_id, subK.external_name from ddp_kit_request_settings dkc " +
-            "            LEFT JOIN sub_kits_settings subK ON (subK.ddp_kit_request_settings_id = dkc.ddp_kit_request_settings_id)) as subkits ON (subkits.kit_type_id = request.kit_type_id) " +
-            "            WHERE ex.ddp_participant_exit_id is null AND request.ddp_instance_id = ? AND NOT external_order_status <=> 'CANCELLED' AND external_order_number IS NOT NULL " ;
+    public static final String SQL_SELECT_EXTERNAL_KIT_NOT_DONE = "SELECT * FROM (SELECT kt.kit_type_name, ddp_site.instance_name, ddp_site.ddp_instance_id, ddp_site.base_url, ddp_site.auth0_token, ddp_site.migrated_ddp,\n" +
+            "                        ddp_site.collaborator_id_prefix, req.bsp_collaborator_sample_id, req.ddp_participant_id, req.ddp_label, req.dsm_kit_request_id, req.bsp_collaborator_participant_id,\n" +
+            "                        req.kit_type_id, req.external_order_status, req.external_order_number, req.external_order_date, req.external_response, kt.no_return, req.created_by, kit.kit_label FROM kit_type kt, ddp_kit_request req, ddp_kit kit, ddp_instance ddp_site\n" +
+            "                        WHERE req.ddp_instance_id = ddp_site.ddp_instance_id AND req.kit_type_id = kt.kit_type_id AND kit.dsm_kit_request_id = req.dsm_kit_request_id\n" +
+            "                        and kit.test_result is null and kit.CE_order is null\n" +
+            "                        and not (kit.ups_tracking_status is not null\n" +
+            "                                and kit.ups_return_status is not null)\n" +
+            "                        ) AS request\n" +
+            "                        LEFT JOIN ddp_participant_exit ex ON (ex.ddp_instance_id = request.ddp_instance_id AND ex.ddp_participant_id = request.ddp_participant_id)\n" +
+            "                        LEFT JOIN (SELECT subK.kit_type_id, subK.external_name from ddp_kit_request_settings dkc\n" +
+            "                        LEFT JOIN sub_kits_settings subK ON (subK.ddp_kit_request_settings_id = dkc.ddp_kit_request_settings_id)) as subkits ON (subkits.kit_type_id = request.kit_type_id)\n" +
+            "                    WHERE ex.ddp_participant_exit_id is null AND request.ddp_instance_id = ? AND NOT external_order_status <=> 'CANCELLED' AND external_order_number IS NOT NULL ";
+
 
     private static final String SQL_SELECT_KIT_REQUEST_BY_EXTERNAL_ORDER_NUMBER = "SELECT dsm_kit_request_id FROM ddp_kit_request req WHERE external_order_number = ?";
     private static final String SQL_SELECT_SENT_KIT_FOR_NOTIFICATION_EXTERNAL_SHIPPER = "select  eve.*,   request.ddp_participant_id,   request.ddp_label, request.upload_reason, request.ddp_kit_request_id, request.dsm_kit_request_id, realm.ddp_instance_id, realm.instance_name, realm.base_url, realm.auth0_token, realm.notification_recipients, realm.migrated_ddp, kit.receive_date, kit.scan_date" +
@@ -341,6 +340,7 @@ public class GBFRequestUtil implements ExternalShipper {
      */
     private void updateOrderStatusForPendingKitRequests(int instanceId, String query) {
         final AtomicInteger numOrdersProcessed = new AtomicInteger();
+        final Set<String> queriedOrderIds = new HashSet<>();
         SimpleResult results = inTransaction((conn) -> {
             SimpleResult dbVals = new SimpleResult();
             try (PreparedStatement stmt = conn.prepareStatement(query)) {
@@ -354,9 +354,12 @@ public class GBFRequestUtil implements ExternalShipper {
                                     rs.getString(DBConstants.EXTERNAL_ORDER_STATUS),
                                     rs.getString("subkits." + DBConstants.EXTERNAL_KIT_NAME),
                                     rs.getLong(DBConstants.EXTERNAL_ORDER_DATE));
-                            numOrdersProcessed.incrementAndGet();
                             try {
-                                orderStatus(conn, kitRequest);
+                                if (!queriedOrderIds.contains(kitRequest.getExternalOrderNumber())) {
+                                    orderStatus(conn, kitRequest);
+                                    numOrdersProcessed.incrementAndGet();
+                                    queriedOrderIds.add(kitRequest.getExternalOrderNumber());
+                                }
                             } catch (Exception e) {
                                 logger.error("Could not check status of kit request " + kitRequest.getExternalOrderNumber(), e);
                             }

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
@@ -354,7 +354,7 @@ public class GBFRequestUtil implements ExternalShipper {
                 try (ResultSet rs = stmt.executeQuery()) {
                     while (rs.next()) {
                         String ddpParticipantId = rs.getString(DBConstants.DDP_PARTICIPANT_ID);
-                        logger.info("querying ES for ddpParticipantId: "+ddpParticipantId);
+//                        logger.info("querying ES for ddpParticipantId: "+ddpParticipantId);
                         if (StringUtils.isNotBlank(ddpParticipantId)) {
 //                            Map participantsESData = getParticipant(ddpInstance, ddpParticipantId);
 //                            if (participantsESData != null && !participantsESData.isEmpty()) {

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
@@ -355,7 +355,7 @@ public class GBFRequestUtil implements ExternalShipper {
                         if (StringUtils.isNotBlank(ddpParticipantId)) {
                             Map participantsESData = getParticipant(ddpInstance, ddpParticipantId);
                             if (participantsESData != null && !participantsESData.isEmpty()) {
-                                DDPParticipant ddpParticipant = ElasticSearchUtil.getParticipantAsDDPParticipant(participantsESData, rs.getString(DBConstants.DDP_PARTICIPANT_ID));
+                                DDPParticipant ddpParticipant = ElasticSearchUtil.getParticipantAsDDPParticipant(participantsESData, ddpParticipantId);
                                 logger.info("ddpParticipant found: "+ddpParticipant.getParticipantId());
                                 if (ddpParticipant != null) {
                                     kitRequests.add(new KitRequest(rs.getString(DBConstants.DSM_KIT_REQUEST_ID), ddpParticipantId,

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
@@ -317,6 +317,7 @@ public class GBFRequestUtil implements ExternalShipper {
             ShippingConfirmations shippingConfirmations = objectFromXMLString(ShippingConfirmations.class, gbfResponse.getXML());
             if (shippingConfirmations != null) {
                 List<ShippingConfirmation> confirmationList = shippingConfirmations.getShippingConfirmations();
+                Collections.shuffle(confirmationList);
                 logger.info("Number of confirmations received: " + confirmationList.size());
                 if (confirmationList != null && !confirmationList.isEmpty()) {
                     for (ShippingConfirmation confirmation : confirmationList) {

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
@@ -50,20 +50,21 @@ public class GBFRequestUtil implements ExternalShipper {
 
     private static final Logger logger = LoggerFactory.getLogger(GBFRequestUtil.class);
 
-    public static final String SQL_SELECT_EXTERNAL_KIT_NOT_DONE = "SELECT * FROM (SELECT kt.kit_type_name, ddp_site.instance_name, ddp_site.ddp_instance_id, ddp_site.base_url, ddp_site.auth0_token, ddp_site.migrated_ddp,\n" +
-            "            ddp_site.collaborator_id_prefix, req.bsp_collaborator_sample_id, req.ddp_participant_id, req.ddp_label, req.dsm_kit_request_id, req.bsp_collaborator_participant_id,\n" +
-            "            req.kit_type_id, req.external_order_status, req.external_order_number, req.external_order_date, req.external_response, kt.no_return, req.created_by, kit.kit_label FROM kit_type kt, ddp_kit_request req, ddp_kit kit, ddp_instance ddp_site\n" +
-            "            WHERE req.ddp_instance_id = ddp_site.ddp_instance_id AND req.kit_type_id = kt.kit_type_id AND kit.dsm_kit_request_id = req.dsm_kit_request_id\n" +
-            "            and kit.test_result is null\n" +
-            "            and not (kit.ups_tracking_status like 'D%'\n" +
-            "                    and kit.ups_return_status like 'D%'\n" +
-            "                    and kit.ups_tracking_status is not null\n" +
-            "                    and kit.ups_return_status is not null)\n" +
-            "            ) AS request\n" +
-            "            LEFT JOIN ddp_participant_exit ex ON (ex.ddp_instance_id = request.ddp_instance_id AND ex.ddp_participant_id = request.ddp_participant_id)\n" +
-            "            LEFT JOIN (SELECT subK.kit_type_id, subK.external_name from ddp_kit_request_settings dkc\n" +
-            "            LEFT JOIN sub_kits_settings subK ON (subK.ddp_kit_request_settings_id = dkc.ddp_kit_request_settings_id)) as subkits ON (subkits.kit_type_id = request.kit_type_id)\n" +
-            "            WHERE ex.ddp_participant_exit_id is null AND request.ddp_instance_id = ? AND NOT external_order_status <=> 'CANCELLED' AND external_order_number IS NOT NULL\n";
+    public static final String SQL_SELECT_EXTERNAL_KIT_NOT_DONE = "SELECT * FROM (SELECT kt.kit_type_name, ddp_site.instance_name, ddp_site.ddp_instance_id, ddp_site.base_url, ddp_site.auth0_token, ddp_site.migrated_ddp, " +
+            "            ddp_site.collaborator_id_prefix, req.bsp_collaborator_sample_id, req.ddp_participant_id, req.ddp_label, req.dsm_kit_request_id, req.bsp_collaborator_participant_id, " +
+            "            req.kit_type_id, req.external_order_status, req.external_order_number, req.external_order_date, req.external_response, kt.no_return, req.created_by, kit.kit_label FROM kit_type kt, ddp_kit_request req, ddp_kit kit, ddp_instance ddp_site " +
+            "            WHERE req.ddp_instance_id = ddp_site.ddp_instance_id AND req.kit_type_id = kt.kit_type_id AND kit.dsm_kit_request_id = req.dsm_kit_request_id " +
+            "            and kit.test_result is null " +
+            "            and not (kit.ups_tracking_status like 'D%' " +
+            "                    and kit.ups_return_status like 'D%' " +
+            "                    and kit.ups_tracking_status is not null " +
+            "                    and kit.ups_return_status is not null) " +
+            "            ) AS request " +
+            "            LEFT JOIN ddp_participant_exit ex ON (ex.ddp_instance_id = request.ddp_instance_id AND ex.ddp_participant_id = request.ddp_participant_id) " +
+            "            LEFT JOIN (SELECT subK.kit_type_id, subK.external_name from ddp_kit_request_settings dkc " +
+            "            LEFT JOIN sub_kits_settings subK ON (subK.ddp_kit_request_settings_id = dkc.ddp_kit_request_settings_id)) as subkits ON (subkits.kit_type_id = request.kit_type_id) " +
+            "            WHERE ex.ddp_participant_exit_id is null AND request.ddp_instance_id = ? AND NOT external_order_status <=> 'CANCELLED' AND external_order_number IS NOT NULL " +
+            "            AND kit.kit_complete is null";
 
     private static final String SQL_SELECT_KIT_REQUEST_BY_EXTERNAL_ORDER_NUMBER = "SELECT dsm_kit_request_id FROM ddp_kit_request req WHERE external_order_number = ?";
     private static final String SQL_SELECT_SENT_KIT_FOR_NOTIFICATION_EXTERNAL_SHIPPER = "select  eve.*,   request.ddp_participant_id,   request.ddp_label, request.upload_reason, request.ddp_kit_request_id, request.dsm_kit_request_id, realm.ddp_instance_id, realm.instance_name, realm.base_url, realm.auth0_token, realm.notification_recipients, realm.migrated_ddp, kit.receive_date, kit.scan_date" +
@@ -85,9 +86,9 @@ public class GBFRequestUtil implements ExternalShipper {
     private final String DISTRIBUTED = "DISTRIBUTION"; //INDICATES: the order is in the final stages of shipping / Can no longer be ‘Cancelled’
     private final String SHIPPED = "SHIPPED"; //INDICATES: the order has been shipped and is with the carrier
 
-    private final String XML_NODE_EXPRESSION = "/ShippingConfirmations/ShippingConfirmation[@OrderNumber=\'%1\']";
+    private static final String XML_NODE_EXPRESSION = "/ShippingConfirmations/ShippingConfirmation[@OrderNumber=\'%1\']";
 
-    public final String EXTERNAL_SHIPPER_NAME = "gbf";
+    public static final String EXTERNAL_SHIPPER_NAME = "gbf";
 
     private static int additionalAttempts = 1;
     private static int sleepInMs = 500;
@@ -269,7 +270,7 @@ public class GBFRequestUtil implements ExternalShipper {
         }
     }
 
-    private void processingSingleConfirmation(Response gbfResponse, List<KitRequest> kitRequests, ShippingConfirmation confirmation) throws Exception {
+    public static void processingSingleConfirmation(Response gbfResponse, List<KitRequest> kitRequests, ShippingConfirmation confirmation) throws Exception {
         //update external shipper response at request
         logger.info("Got confirmation for " + confirmation.getOrderNumber());
         Node node = GBFRequestUtil.getXMLNode(gbfResponse.getXML(), XML_NODE_EXPRESSION.replace("%1", confirmation.getOrderNumber()));
@@ -340,14 +341,17 @@ public class GBFRequestUtil implements ExternalShipper {
     }
 
     public ArrayList<KitRequest> getKitRequestsNotDone(int instanceId) {
+        return getKitRequestsNotDone(instanceId,SQL_SELECT_EXTERNAL_KIT_NOT_DONE );
+    }
+
+    public  ArrayList<KitRequest> getKitRequestsNotDone(int instanceId, String query) {
         DDPInstance ddpInstance = DDPInstance.getDDPInstanceById(instanceId);
 
-            ArrayList<KitRequest> kitRequests = new ArrayList<>();
+        ArrayList<KitRequest> kitRequests = new ArrayList<>();
         SimpleResult results = inTransaction((conn) -> {
             SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement stmt = conn.prepareStatement(SQL_SELECT_EXTERNAL_KIT_NOT_DONE)) {
+            try (PreparedStatement stmt = conn.prepareStatement(query)) {
                 stmt.setInt(1, instanceId);
-
                 try (ResultSet rs = stmt.executeQuery()) {
                     while (rs.next()) {
                         String ddpParticipantId = rs.getString(DBConstants.DDP_PARTICIPANT_ID);
@@ -386,7 +390,7 @@ public class GBFRequestUtil implements ExternalShipper {
         return kitRequests;
     }
 
-    public List<String> getDSMKitRequestId(String externalOrderNumber) {
+    public static  List<String> getDSMKitRequestId(String externalOrderNumber) {
         List<String> dsmKitRequestIds = new ArrayList<>();
         SimpleResult results = inTransaction((conn) -> {
             SimpleResult dbVals = new SimpleResult();
@@ -411,7 +415,7 @@ public class GBFRequestUtil implements ExternalShipper {
         return dsmKitRequestIds;
     }
 
-    private List<KitRequest> getKitRequest(@NonNull List<KitRequest> kitRequests, @NonNull String externalOrderNumber, String subKitName, int tubeNumber) {
+    private static List<KitRequest> getKitRequest(@NonNull List<KitRequest> kitRequests, @NonNull String externalOrderNumber, String subKitName, int tubeNumber) {
         int counter = -1;
         ArrayList<KitRequest> kitRequestsResult = new ArrayList<>();
         for (KitRequest kitRequest : kitRequests) {

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
@@ -519,13 +519,15 @@ public class GBFRequestUtil implements ExternalShipper {
     public static Map getParticipants(String realm, String ddpParticipantId) {
         DDPInstance ddpInstance = DDPInstance.getDDPInstanceWithRole(realm, DBConstants.NEEDS_NAME_LABELS);
         Map<String, Map<String, Object>> participantsESData = null;
-        String filter = "AND profile.guid = ";
+        String filter = "AND profile.guid = '";
 
         if (StringUtils.isNotBlank(ddpInstance.getParticipantIndexES())) {
             StringBuilder builder = new StringBuilder();
             builder.append(filter);
             builder.append(ddpParticipantId);
-            participantsESData = ElasticSearchUtil.getFilteredDDPParticipantsFromES(ddpInstance, builder.toString());
+            builder.append("'");
+            String queryFiler = builder.toString();
+            participantsESData = ElasticSearchUtil.getFilteredDDPParticipantsFromES(ddpInstance, queryFiler);
         }
         return participantsESData;
     }

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
@@ -274,7 +274,7 @@ public class GBFRequestUtil implements ExternalShipper {
         logger.info("Got confirmation for " + confirmation.getOrderNumber());
         Node node = GBFRequestUtil.getXMLNode(gbfResponse.getXML(), XML_NODE_EXPRESSION.replace("%1", confirmation.getOrderNumber()));
         String externalResponse = getStringFromNode(node);
-        if (confirmation.getItem() != null) {
+        if (confirmation.getItem() != null && StringUtils.isNotBlank(externalResponse)) {
             Item item = confirmation.getItem();
             inTransaction((conn) -> {
                 List<String> dsmKitRequestIds = getDSMKitRequestId(conn, confirmation.getOrderNumber()); //dsm_kit_request_id
@@ -301,7 +301,7 @@ public class GBFRequestUtil implements ExternalShipper {
                 return null;
             });
         } else {
-            logger.error("No items for order " + confirmation.getOrderNumber());
+            logger.error("No items or external response for order " + confirmation.getOrderNumber());
         }
     }
 

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
@@ -53,18 +53,17 @@ public class GBFRequestUtil implements ExternalShipper {
     private static final Logger logger = LoggerFactory.getLogger(GBFRequestUtil.class);
 
     public static final String SQL_SELECT_EXTERNAL_KIT_NOT_DONE = "SELECT * FROM (SELECT kt.kit_type_name, ddp_site.instance_name, ddp_site.ddp_instance_id, ddp_site.base_url, ddp_site.auth0_token, ddp_site.migrated_ddp,\n" +
-            "                        ddp_site.collaborator_id_prefix, req.bsp_collaborator_sample_id, req.ddp_participant_id, req.ddp_label, req.dsm_kit_request_id, req.bsp_collaborator_participant_id,\n" +
-            "                        req.kit_type_id, req.external_order_status, req.external_order_number, req.external_order_date, req.external_response, kt.no_return, req.created_by, kit.kit_label FROM kit_type kt, ddp_kit_request req, ddp_kit kit, ddp_instance ddp_site\n" +
-            "                        WHERE req.ddp_instance_id = ddp_site.ddp_instance_id AND req.kit_type_id = kt.kit_type_id AND kit.dsm_kit_request_id = req.dsm_kit_request_id\n" +
-            "                        and kit.test_result is null and kit.CE_order is null\n" +
-            "                        and (kit.ups_tracking_status is null\n" +
-            "                             or kit.ups_return_status is null)\n" +
-            "                        ) AS request\n" +
-            "                        LEFT JOIN ddp_participant_exit ex ON (ex.ddp_instance_id = request.ddp_instance_id AND ex.ddp_participant_id = request.ddp_participant_id)\n" +
-            "                        LEFT JOIN (SELECT subK.kit_type_id, subK.external_name from ddp_kit_request_settings dkc\n" +
-            "                        LEFT JOIN sub_kits_settings subK ON (subK.ddp_kit_request_settings_id = dkc.ddp_kit_request_settings_id)) as subkits ON (subkits.kit_type_id = request.kit_type_id)\n" +
-            "                    WHERE ex.ddp_participant_exit_id is null AND request.ddp_instance_id = ? AND (external_order_status not like '%CANCELLED%' or external_order_status is null) AND external_order_number IS NOT NULL\n" +
-            "                    order by request.dsm_kit_request_id desc ";
+            "                                    ddp_site.collaborator_id_prefix, req.bsp_collaborator_sample_id, req.ddp_participant_id, req.ddp_label, req.dsm_kit_request_id, req.bsp_collaborator_participant_id,\n" +
+            "                                    req.kit_type_id, req.external_order_status, req.external_order_number, req.external_order_date, req.external_response, kt.no_return, req.created_by, kit.kit_label FROM kit_type kt, ddp_kit_request req, ddp_kit kit, ddp_instance ddp_site\n" +
+            "                                    WHERE req.ddp_instance_id = ddp_site.ddp_instance_id AND req.kit_type_id = kt.kit_type_id AND kit.dsm_kit_request_id = req.dsm_kit_request_id\n" +
+            "                                    and kit.test_result is null and kit.CE_order is null\n" +
+            "                                    and (kit.kit_label is null or kit.tracking_return_id is null or kit.tracking_to_id is null))\n" +
+            "                                     AS request\n" +
+            "                                    LEFT JOIN ddp_participant_exit ex ON (ex.ddp_instance_id = request.ddp_instance_id AND ex.ddp_participant_id = request.ddp_participant_id)\n" +
+            "                                    LEFT JOIN (SELECT subK.kit_type_id, subK.external_name from ddp_kit_request_settings dkc\n" +
+            "                                    LEFT JOIN sub_kits_settings subK ON (subK.ddp_kit_request_settings_id = dkc.ddp_kit_request_settings_id)) as subkits ON (subkits.kit_type_id = request.kit_type_id)\n" +
+            "                                WHERE ex.ddp_participant_exit_id is null AND request.ddp_instance_id = ? AND (external_order_status not like '%CANCELLED%' or external_order_status is null) AND external_order_number IS NOT NULL\n" +
+            "                                order by request.dsm_kit_request_id desc ";
 
 
     private static final String SQL_SELECT_KIT_REQUEST_BY_EXTERNAL_ORDER_NUMBER = "SELECT dsm_kit_request_id FROM ddp_kit_request req WHERE external_order_number = ?";

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
@@ -343,7 +343,7 @@ public class GBFRequestUtil implements ExternalShipper {
         return getKitRequestsNotDone(instanceId,SQL_SELECT_EXTERNAL_KIT_NOT_DONE );
     }
 
-    public  ArrayList<KitRequest> getKitRequestsNotDone(int instanceId, String query) {
+    public  ArrayList<KitRequest>   getKitRequestsNotDone(int instanceId, String query) {
         DDPInstance ddpInstance = DDPInstance.getDDPInstanceById(instanceId);
 
         ArrayList<KitRequest> kitRequests = new ArrayList<>();
@@ -356,21 +356,21 @@ public class GBFRequestUtil implements ExternalShipper {
                         String ddpParticipantId = rs.getString(DBConstants.DDP_PARTICIPANT_ID);
                         logger.info("querying ES for ddpParticipantId: "+ddpParticipantId);
                         if (StringUtils.isNotBlank(ddpParticipantId)) {
-                            Map participantsESData = getParticipant(ddpInstance, ddpParticipantId);
-                            if (participantsESData != null && !participantsESData.isEmpty()) {
-                                DDPParticipant ddpParticipant = ElasticSearchUtil.getParticipantAsDDPParticipant(participantsESData, ddpParticipantId);
-                                logger.info("ddpParticipant found: "+ddpParticipant.getParticipantId());
-                                if (ddpParticipant != null) {
+//                            Map participantsESData = getParticipant(ddpInstance, ddpParticipantId);
+//                            if (participantsESData != null && !participantsESData.isEmpty()) {
+//                                DDPParticipant ddpParticipant = ElasticSearchUtil.getParticipantAsDDPParticipant(participantsESData, ddpParticipantId);
+//                                logger.info("ddpParticipant found: "+ddpParticipant.getParticipantId());
+//                                if (ddpParticipant != null) {
                                     kitRequests.add(new KitRequest(rs.getString(DBConstants.DSM_KIT_REQUEST_ID), ddpParticipantId,
-                                            null, null, rs.getString(DBConstants.EXTERNAL_ORDER_NUMBER), ddpParticipant,
+                                            null, null, rs.getString(DBConstants.EXTERNAL_ORDER_NUMBER), null,
                                             rs.getString(DBConstants.EXTERNAL_ORDER_STATUS),
                                             rs.getString("subkits." + DBConstants.EXTERNAL_KIT_NAME),
                                             rs.getLong(DBConstants.EXTERNAL_ORDER_DATE)));
-                                }
-                            }
-                            else {
-                                logger.error("Participant not found in ES! " + ddpParticipantId);
-                            }
+//                                }
+//                            }
+//                            else {
+//                                logger.error("Participant not found in ES! " + ddpParticipantId);
+//                            }
 
                         }
                     }

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
@@ -344,7 +344,7 @@ public class GBFRequestUtil implements ExternalShipper {
     public ArrayList<KitRequest> getKitRequestsNotDone(int instanceId) {
         DDPInstance ddpInstance = DDPInstance.getDDPInstanceById(instanceId);
 
-        ArrayList<KitRequest> kitRequests = new ArrayList<>();
+            ArrayList<KitRequest> kitRequests = new ArrayList<>();
         SimpleResult results = inTransaction((conn) -> {
             SimpleResult dbVals = new SimpleResult();
             try (PreparedStatement stmt = conn.prepareStatement(SQL_SELECT_EXTERNAL_KIT_NOT_DONE)) {
@@ -352,7 +352,7 @@ public class GBFRequestUtil implements ExternalShipper {
 
                 try (ResultSet rs = stmt.executeQuery()) {
                     while (rs.next()) {
-                        String ddpParticipantId = rs.getString("req.ddp_participant_id");
+                        String ddpParticipantId = rs.getString("ddp_participant_id");
                         logger.info("qyerying ES for ddpParticipantId: "+ddpParticipantId);
                         if (StringUtils.isNotBlank(ddpParticipantId)) {
                             Map participantsESData = getParticipants(ddpInstance.getName(), ddpParticipantId);
@@ -519,13 +519,12 @@ public class GBFRequestUtil implements ExternalShipper {
     public static Map getParticipants(String realm, String ddpParticipantId) {
         DDPInstance ddpInstance = DDPInstance.getDDPInstanceWithRole(realm, DBConstants.NEEDS_NAME_LABELS);
         Map<String, Map<String, Object>> participantsESData = null;
-        String filter = "AND profile.guid = '";
+        String filter = "AND profile.guid = ";
 
         if (StringUtils.isNotBlank(ddpInstance.getParticipantIndexES())) {
             StringBuilder builder = new StringBuilder();
             builder.append(filter);
             builder.append(ddpParticipantId);
-            builder.append("'");
             participantsESData = ElasticSearchUtil.getFilteredDDPParticipantsFromES(ddpInstance, builder.toString());
         }
         return participantsESData;

--- a/src/test/java/org/broadinstitute/dsm/GBFTest.java
+++ b/src/test/java/org/broadinstitute/dsm/GBFTest.java
@@ -176,15 +176,15 @@ public class GBFTest extends TestHelper {
             Response gbfResponse = GBFRequestUtil.executePost(Response.class, sendRequest, payload.toString(), apiKey);
 
             GBFRequestUtil gbf = new GBFRequestUtil();
-            String query = "SELECT * " +
-                    "FROM prod_dsm_db.ddp_kit_request req  " +
-                    "LEFT JOIN ddp_kit kit ON  " +
-                    "(req.dsm_kit_request_id = kit.dsm_kit_request_id) " +
-                    "WHERE " +
-                    "req.ddp_instance_id = ?  " +
-                    "AND external_order_status = 'SHIPPED' " +
-                    "AND external_response is null " +
-                    "ORDER BY external_order_date ASC ";
+                String query = "SELECT * " +
+                        "FROM ddp_kit_request req  " +
+                        "LEFT JOIN ddp_kit kit ON  " +
+                        "(req.dsm_kit_request_id = kit.dsm_kit_request_id) " +
+                        "WHERE " +
+                        "req.ddp_instance_id = ?  " +
+                        "AND external_order_status = 'SHIPPED' " +
+                        "AND external_response is null " +
+                        "ORDER BY external_order_date ASC ";
 
             ArrayList<KitRequest> kitRequests = gbf.getKitRequestsNotDone(Integer.parseInt(DDPInstance.getDDPInstance("testboston").getDdpInstanceId()), query);
 

--- a/src/test/java/org/broadinstitute/dsm/GBFTest.java
+++ b/src/test/java/org/broadinstitute/dsm/GBFTest.java
@@ -178,8 +178,9 @@ public class GBFTest extends TestHelper {
             GBFRequestUtil gbf = new GBFRequestUtil();
                 String query = "SELECT * " +
                         "FROM ddp_kit_request req  " +
-                        "LEFT JOIN ddp_kit kit ON  " +
-                        "(req.dsm_kit_request_id = kit.dsm_kit_request_id) " +
+                        "LEFT JOIN ddp_kit kit ON (req.dsm_kit_request_id = kit.dsm_kit_request_id)  " +
+                        "LEFT JOIN ddp_participant_exit ex ON (ex.ddp_instance_id = req.ddp_instance_id AND ex.ddp_participant_id = req.ddp_participant_id)   " +
+                        "LEFT JOIN (SELECT subK.kit_type_id, subK.external_name from ddp_kit_request_settings dkc   LEFT JOIN sub_kits_settings subK ON (subK.ddp_kit_request_settings_id = dkc.ddp_kit_request_settings_id)) as subkits ON (subkits.kit_type_id = req.kit_type_id)   " +
                         "WHERE " +
                         "req.ddp_instance_id = ?  " +
                         "AND external_order_status = 'SHIPPED' " +

--- a/src/test/java/org/broadinstitute/dsm/GBFTest.java
+++ b/src/test/java/org/broadinstitute/dsm/GBFTest.java
@@ -4,10 +4,12 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import org.apache.commons.lang3.StringUtils;
-import org.broadinstitute.dsm.TestHelper;
+import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.model.KitRequest;
 import org.broadinstitute.dsm.model.gbf.*;
 import org.broadinstitute.dsm.statics.ApplicationConfigConstants;
+import org.broadinstitute.dsm.statics.DBConstants;
+import org.broadinstitute.dsm.util.DBUtil;
 import org.broadinstitute.dsm.util.SystemUtil;
 import org.broadinstitute.dsm.util.externalShipper.ExternalShipper;
 import org.broadinstitute.dsm.util.externalShipper.GBFRequestUtil;
@@ -16,8 +18,9 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -27,6 +30,8 @@ public class GBFTest extends TestHelper {
     private String GBF_URL = "https://www.gbfmedical.com/oap/api/";
     private String ORDER_NUMBER = "WEB123ABC4D5";
 
+    private static final Logger logger = LoggerFactory.getLogger(GBFTest.class);
+
     @BeforeClass
     public static void before() throws Exception {
         setupDB();
@@ -35,7 +40,7 @@ public class GBFTest extends TestHelper {
 
     public String getApiKey() {
         String apiKey = null;
-        JsonArray array = (JsonArray)(new JsonParser().parse(cfg.getString("externalShipper")));
+        JsonArray array = (JsonArray) (new JsonParser().parse(cfg.getString("externalShipper")));
         for (JsonElement ddpInfo : array) {
             if (ddpInfo.isJsonObject()) {
                 if ("gbf".equals(ddpInfo.getAsJsonObject().get(ApplicationConfigConstants.SHIPPER_NAME).getAsString().toLowerCase())) {
@@ -59,7 +64,7 @@ public class GBFTest extends TestHelper {
             ShippingInfo shippingInfo = new ShippingInfo(null, "FEDEX_2_DAY", address);
             List<LineItem> lineItems = new ArrayList<>();
             lineItems.add(new LineItem("K-DFC-PROMISE", "1"));
-            Order order = new Order(ORDER_NUMBER, "C7037154","00001", shippingInfo, lineItems);
+            Order order = new Order(ORDER_NUMBER, "C7037154", "00001", shippingInfo, lineItems);
             orders.getOrders().add(order);
 
             String orderXml = GBFRequestUtil.orderXmlToString(Orders.class, orders);
@@ -113,11 +118,11 @@ public class GBFTest extends TestHelper {
         String apiKey = "";
         if (apiKey != null) {
             List<String> orderNumbers = new ArrayList<>();
-            orderNumbers.addAll(Arrays.asList(new String[] {""}));
-//            logger.info("Starting the external shipper job");
+            orderNumbers.addAll(Arrays.asList(new String[] { "" }));
+            //            logger.info("Starting the external shipper job");
             ExternalShipper shipper = (ExternalShipper) Class.forName("org.broadinstitute.dsm.util.externalShipper.GBFRequestUtil").newInstance(); //to get blindTestExecutor instance
-//            ArrayList<KitRequest> kitRequests = shipper.getKitRequestsNotDone(9);
-//            shipper.orderStatus(kitRequests);;
+            //            ArrayList<KitRequest> kitRequests = shipper.getKitRequestsNotDone(9);
+            //            shipper.orderStatus(kitRequests);;
             JSONObject payload = new JSONObject().put("orderNumbers", orderNumbers);
 
             String sendRequest = GBF_URL + GBFRequestUtil.STATUS_ENDPOINT;
@@ -125,10 +130,10 @@ public class GBFTest extends TestHelper {
 
             Assert.assertNotNull(gbfResponse);
             Assert.assertTrue(gbfResponse.isSuccess());
-//            Assert.assertTrue(StringUtils.isBlank(gbfResponse.getErrorMessage()));
-//            List<Status> statuses = gbfResponse.getStatuses();
-//            Assert.assertTrue(statuses.size() == 1);
-//            Assert.assertTrue(!statuses.get(0).getOrderStatus().equals("NOT FOUND"));
+            //            Assert.assertTrue(StringUtils.isBlank(gbfResponse.getErrorMessage()));
+            //            List<Status> statuses = gbfResponse.getStatuses();
+            //            Assert.assertTrue(statuses.size() == 1);
+            //            Assert.assertTrue(!statuses.get(0).getOrderStatus().equals("NOT FOUND"));
         }
         else {
             Assert.fail("No apiKey found");
@@ -140,13 +145,71 @@ public class GBFTest extends TestHelper {
     public void confirmationGBFKit() throws Exception {
         String apiKey = "";
         if (apiKey != null) {
-            long testDate = 1603468306000L; //change that to the date of testing!
-            long start = 1603252800000L;
+            long testDate = 1609172139000L; //change that to the date of testing!
+            long start = 0;
             long end = testDate;
 
             JSONObject payload = new JSONObject().put("startDate", SystemUtil.getDateFormatted(start)).put("endDate", SystemUtil.getDateFormatted(end));
             String sendRequest = GBF_URL + GBFRequestUtil.CONFIRM_ENDPOINT;
             Response gbfResponse = GBFRequestUtil.executePost(Response.class, sendRequest, payload.toString(), apiKey);
+            Assert.assertNotNull(gbfResponse);
+            Assert.assertTrue(StringUtils.isNotBlank(gbfResponse.getXML()));
+
+        }
+        else {
+            Assert.fail("No apiKey found");
+        }
+    }
+
+
+    @Test
+    @Ignore
+    public void inputConfirmationGBFKit() throws Exception {
+        String apiKey = "";
+        if (apiKey != null) {
+            long testDate = 1609172139000L; //change that to the date of testing!
+            long start = 0;
+            long end = testDate;
+
+            JSONObject payload = new JSONObject().put("startDate", SystemUtil.getDateFormatted(start)).put("endDate", SystemUtil.getDateFormatted(end));
+            String sendRequest = GBF_URL + GBFRequestUtil.CONFIRM_ENDPOINT;
+            Response gbfResponse = GBFRequestUtil.executePost(Response.class, sendRequest, payload.toString(), apiKey);
+
+            GBFRequestUtil gbf = new GBFRequestUtil();
+            String query = "SELECT * " +
+                    "FROM prod_dsm_db.ddp_kit_request req  " +
+                    "LEFT JOIN ddp_kit kit ON  " +
+                    "(req.dsm_kit_request_id = kit.dsm_kit_request_id) " +
+                    "WHERE " +
+                    "req.ddp_instance_id = ?  " +
+                    "AND external_order_status = 'SHIPPED' " +
+                    "AND external_response is null " +
+                    "ORDER BY external_order_date ASC ";
+
+            ArrayList<KitRequest> kitRequests = gbf.getKitRequestsNotDone(Integer.parseInt(DDPInstance.getDDPInstance("testboston").getDdpInstanceId()), query);
+
+            if (gbfResponse != null && StringUtils.isNotBlank(gbfResponse.getXML())) {
+                logger.info("Confirmation xmls received! ");
+                ShippingConfirmations shippingConfirmations = gbf.objectFromXMLString(ShippingConfirmations.class, gbfResponse.getXML());
+                if (shippingConfirmations != null) {
+                    List<ShippingConfirmation> confirmationList = shippingConfirmations.getShippingConfirmations();
+                    logger.info("Number of confirmations received: " + confirmationList.size());
+                    if (confirmationList != null && !confirmationList.isEmpty()) {
+                        for (ShippingConfirmation confirmation : confirmationList) {
+                            try {
+                                gbf.processingSingleConfirmation(gbfResponse, kitRequests, confirmation);
+                            }
+                            catch (Exception e) {
+                                logger.error("Could not process confirmation for " + confirmation.getOrderNumber(), e);
+                            }
+                        }
+                        DBUtil.updateBookmark(testDate, DBConstants.GBF_CONFIRMATION);
+                    }
+                    else {
+                        logger.info("No shipping confirmation returned");
+                    }
+                }
+            }
             Assert.assertNotNull(gbfResponse);
             Assert.assertTrue(StringUtils.isNotBlank(gbfResponse.getXML()));
 

--- a/src/test/java/org/broadinstitute/dsm/GBFTest.java
+++ b/src/test/java/org/broadinstitute/dsm/GBFTest.java
@@ -169,7 +169,7 @@ public class GBFTest extends TestHelper {
         String apiKey = "";
         if (apiKey != null) {
             long testDate = 1609172139000L; //change that to the date of testing!
-            long start = 1608613200000L;
+            long start = 0L;
             long end = testDate;
 
             JSONObject payload = new JSONObject().put("startDate", SystemUtil.getDateFormatted(start)).put("endDate", SystemUtil.getDateFormatted(end));
@@ -180,7 +180,6 @@ public class GBFTest extends TestHelper {
             String query = "SELECT * " +
                     "FROM ddp_kit_request req  " +
                     "LEFT JOIN ddp_kit kit ON (req.dsm_kit_request_id = kit.dsm_kit_request_id)  " +
-                    "LEFT JOIN ddp_participant_exit ex ON (ex.ddp_instance_id = req.ddp_instance_id AND ex.ddp_participant_id = req.ddp_participant_id)   " +
                     "LEFT JOIN (SELECT subK.kit_type_id, subK.external_name from ddp_kit_request_settings dkc   LEFT JOIN sub_kits_settings subK ON (subK.ddp_kit_request_settings_id = dkc.ddp_kit_request_settings_id)) as subkits ON (subkits.kit_type_id = req.kit_type_id)   " +
                     "WHERE " +
                     "req.ddp_instance_id = ?  " +

--- a/src/test/java/org/broadinstitute/dsm/GBFTest.java
+++ b/src/test/java/org/broadinstitute/dsm/GBFTest.java
@@ -204,7 +204,7 @@ public class GBFTest extends TestHelper {
                         for (ShippingConfirmation confirmation : confirmationList) {
                             if (kits.containsKey(confirmation.getOrderNumber())) {
                                 try {
-                                    gbf.processingSingleConfirmation(gbfResponse, kitRequests, confirmation);
+                                    gbf.processingSingleConfirmation(gbfResponse, confirmation);
                                 }
                                 catch (Exception e) {
                                     logger.error("Could not process confirmation for " + confirmation.getOrderNumber(), e);

--- a/src/test/java/org/broadinstitute/dsm/QuartzExternalShipperTest.java
+++ b/src/test/java/org/broadinstitute/dsm/QuartzExternalShipperTest.java
@@ -64,7 +64,7 @@ public class QuartzExternalShipperTest extends TestHelper {
     public void externalShipperJob() throws Exception {
 //        uploadKit();
 
-        ExternalShipper shipper = (ExternalShipper) Class.forName(DSMServer.getClassName("gbf")).newInstance();//GBFRequestUtil
+        GBFRequestUtil shipper = new GBFRequestUtil();
         ArrayList<KitRequest> kitRequests = shipper.getKitRequestsNotDone(15);
         Map<Integer, KitRequestSettings> kitRequestSettingsMap = KitRequestSettings.getKitRequestSettings("15");
         shipper.orderKitRequests(kitRequests, new EasyPostUtil("testboston"), kitRequestSettingsMap.get(11), null       );


### PR DESCRIPTION
For DDP-5479, we can reduce the number of calls we make to GBF status endpoint by:
* ignoring things that have been ordered in CE
* ignoring UPS status--it's not relevant here
* eliminating redundant calls for the same kit