### PR TITLE
Cloud Function POC

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ To download this dependency, generate a github token and add it to your `~/.m2/s
 
 ````
 
+DSM uses a single `pom.xml` but two different profile values for building the backend APIs
+for GAE and background jobs for Cloud Functions.  When building the APIs, use `-Papis`.  To 
+build cloud functions, use `Pcloud-function`
+
 # Secrets
 DSM uses GCP's [secret manager (SM)](https://cloud.google.com/secret-manager) to store credentials.
 
@@ -100,6 +104,10 @@ on your local machine, then you can set `-Dserver.static_content_source=/foo/bar
 [localhost](http://localhost:4567).
 
 # Building and deploying
+DSM has two components: the backend APIS and Cloud Functions, which are essentially background tasks.
+
+### Building and deploying backend APIS
+
 To deploy to a specific project, just run the `build-and-deploy` script, which takes two args: the name of a project and the name
 of the GCP secret to read from said project.  To deploy to dev:
 
@@ -108,5 +116,16 @@ cd appengine/deploy
 ./build-and-deploy.sh broad-ddp-dev study-manager-config
 ```
 
+### Building and deploying cloud functions
+ ```
+ ./build-and-deploy-cloud-functions.sh project gcp-secret study-manager-schema study-server-schema
+ ```
+
+
 # Viewing Logs
-One way to view logs is via the [GCP console](https://console.cloud.google.com/logs/viewer).  Drill into `GAE Application -> study-manager-backend -> version`.
+One way to view logs is via the [GCP console](https://console.cloud.google.com/logs/viewer).  \
+
+
+For backend API logs, drill into `GAE Application -> study-manager-backend -> version`.
+
+For could functions, use the `resource.type="cloud_function"` resource.

--- a/appengine/deploy/build-and-deploy.sh
+++ b/appengine/deploy/build-and-deploy.sh
@@ -19,12 +19,12 @@ echo "=> reading configs from cloud secret manager"
 gcloud --project=${PROJECT_ID} secrets versions access latest --secret="${CONFIG_SECRETS}" > vault.conf
 
 echo "=> running build"
-mvn -DskipTests clean install package -f ../../pom.xml
+mvn -Papis -DskipTests clean install package -f ../../pom.xml
 
 # bundling dependencies
 rm -fr lib
 mkdir -p lib
-mvn -f ../../pom.xml dependency:copy-dependencies -DoutputDirectory=./appengine/deploy/lib
+mvn -Papis -f ../../pom.xml dependency:copy-dependencies -DoutputDirectory=./appengine/deploy/lib
 cp ../../target/DSMServer.jar .
 cp ../../src/main/resources/log4j.xml .
 

--- a/build-and-deploy-cloud-functions.sh
+++ b/build-and-deploy-cloud-functions.sh
@@ -5,7 +5,7 @@ STUDY_SERVER_SCHEMA=$4
 
 echo "Will deploy to ${PROJECT_ID} using schemas ${STUDY_MANAGER_SCHEMA} and ${STUDY_SERVER_SCHEMA}"
 
-mvn -Pcloud-function -DskipTests clean install package
+# mvn -Pcloud-function -DskipTests clean install package
 
 
 #echo "Deploying kit dispatcher to ${PROJECT_ID}"
@@ -15,7 +15,9 @@ mvn -Pcloud-function -DskipTests clean install package
 #    --runtime=java11 \
 #    --trigger-topic=kit-report \
 #    --source=target/deployment \
-#    --set-env-vars="PROJECT_ID=${PROJECT_ID},SECRET_ID=cloud-functions,STUDY_MANAGER_SCHEMA=${STUDY_MANAGER_SCHEMA},STUDY_SERVER_SCHEMA=${STUDY_SERVER_SCHEMA}"
+#    --set-env-vars="PROJECT_ID=${PROJECT_ID},SECRET_ID=cloud-functions,STUDY_MANAGER_SCHEMA=${STUDY_MANAGER_SCHEMA},STUDY_SERVER_SCHEMA=${STUDY_SERVER_SCHEMA}" \
+#    --egress-settings=all \
+#    --vpc-connector=appengine-default-connect
 
 
 
@@ -27,4 +29,5 @@ gcloud --project=${PROJECT_ID} functions deploy \
     --trigger-topic=tbos-ce-orders \
     --source=target/deployment \
     --memory=1024MB \
-    --set-env-vars="PROJECT_ID=${PROJECT_ID},SECRET_ID=study-manager-config"
+    --set-env-vars="PROJECT_ID=${PROJECT_ID},SECRET_ID=study-manager-config" \
+    --vpc-connector=projects/broad-ddp-dev/locations/us-central1/connectors/appengine-default-connect

--- a/build-and-deploy-cloud-functions.sh
+++ b/build-and-deploy-cloud-functions.sh
@@ -1,0 +1,18 @@
+
+PROJECT_ID=$1
+SECRET_ID=$2
+STUDY_MANAGER_SCHEMA=$3
+STUDY_SERVER_SCHEMA=$4
+
+echo "Will deploy to ${PROJECT_ID} with ${SECRET_ID} secret using schemas ${STUDY_MANAGER_SCHEMA} and ${STUDY_SERVER_SCHEMA}"
+
+mvn -Pcloud-function -DskipTests clean install package
+
+echo "Deploying to ${PROJECT_ID}"
+gcloud --project=${PROJECT_ID} functions deploy \
+    tbos-kit-tracking-dispatcher \
+    --entry-point=org.broadinstitute.dsm.cf.TestBostonKitTrackerDispatcher \
+    --runtime=java11 \
+    --trigger-topic=kit-report \
+    --source=target/deployment \
+    --set-env-vars="PROJECT_ID=${PROJECT_ID},SECRET_ID=${SECRET_ID},STUDY_MANAGER_SCHEMA=${STUDY_MANAGER_SCHEMA},STUDY_SERVER_SCHEMA=${STUDY_SERVER_SCHEMA}"

--- a/build-and-deploy-cloud-functions.sh
+++ b/build-and-deploy-cloud-functions.sh
@@ -1,18 +1,30 @@
 
 PROJECT_ID=$1
-SECRET_ID=$2
 STUDY_MANAGER_SCHEMA=$3
 STUDY_SERVER_SCHEMA=$4
 
-echo "Will deploy to ${PROJECT_ID} with ${SECRET_ID} secret using schemas ${STUDY_MANAGER_SCHEMA} and ${STUDY_SERVER_SCHEMA}"
+echo "Will deploy to ${PROJECT_ID} using schemas ${STUDY_MANAGER_SCHEMA} and ${STUDY_SERVER_SCHEMA}"
 
 mvn -Pcloud-function -DskipTests clean install package
 
-echo "Deploying to ${PROJECT_ID}"
+
+#echo "Deploying kit dispatcher to ${PROJECT_ID}"
+#gcloud --project=${PROJECT_ID} functions deploy \
+#    tbos-kit-tracking-dispatcher \
+#    --entry-point=org.broadinstitute.dsm.cf.TestBostonKitTrackerDispatcher \
+#    --runtime=java11 \
+#    --trigger-topic=kit-report \
+#    --source=target/deployment \
+#    --set-env-vars="PROJECT_ID=${PROJECT_ID},SECRET_ID=cloud-functions,STUDY_MANAGER_SCHEMA=${STUDY_MANAGER_SCHEMA},STUDY_SERVER_SCHEMA=${STUDY_SERVER_SCHEMA}"
+
+
+
+echo "Deploying covid order registrar to ${PROJECT_ID}"
 gcloud --project=${PROJECT_ID} functions deploy \
-    tbos-kit-tracking-dispatcher \
-    --entry-point=org.broadinstitute.dsm.cf.TestBostonKitTrackerDispatcher \
+    order-in-care-evolve \
+    --entry-point=org.broadinstitute.dsm.cf.Covid19OrderRegistrarFunction \
     --runtime=java11 \
-    --trigger-topic=kit-report \
+    --trigger-topic=tbos-ce-orders \
     --source=target/deployment \
-    --set-env-vars="PROJECT_ID=${PROJECT_ID},SECRET_ID=${SECRET_ID},STUDY_MANAGER_SCHEMA=${STUDY_MANAGER_SCHEMA},STUDY_SERVER_SCHEMA=${STUDY_SERVER_SCHEMA}"
+    --memory=1024MB \
+    --set-env-vars="PROJECT_ID=${PROJECT_ID},SECRET_ID=study-manager-config"

--- a/pom.xml
+++ b/pom.xml
@@ -180,12 +180,6 @@
             <artifactId>xml-apis</artifactId>
             <version>1.4.01</version>
         </dependency>
-        <!--        <dependency>-->
-        <!--            <groupId>javax.xml.bind</groupId>-->
-        <!--            <artifactId>jaxb-api</artifactId>-->
-        <!--            <version>2.3.0</version>-->
-        <!--        </dependency>-->
-        <!-- API, java.xml.bind module -->
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
@@ -234,54 +228,147 @@
             <version>1.1</version>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.glassfish.jaxb/jaxb-runtime -->
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <version>2.3.0-b170127.1453</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.cloud.functions</groupId>
+            <artifactId>functions-framework-api</artifactId>
+            <version>1.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-secretmanager</artifactId>
+        </dependency>
+
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>cloud-function</id>
+            <build>
+                <resources>
+                    <resource>
+                        <directory>src/main/resources</directory>
+                        <filtering>true</filtering>
+                    </resource>
+                </resources>
+                <testResources>
+                    <testResource>
+                        <directory>src/test/resources</directory>
+                    </testResource>
+                </testResources>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.8.0</version>
+                        <configuration>
+                            <release>11</release>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <addClasspath>true</addClasspath>
+                                    <classpathPrefix>libs/</classpathPrefix>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>copy-dependencies</goal>
+                                </goals>
+                                <configuration>
+                                    <overWriteReleases>false</overWriteReleases>
+                                    <includeScope>runtime</includeScope>
+                                    <outputDirectory>${project.build.directory}/libs</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-resources</id>
+                                <phase>package</phase>
+                                <goals><goal>copy-resources</goal></goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}/deployment</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>${project.build.directory}</directory>
+                                            <includes>
+                                                <include>${build.finalName}.jar</include>
+                                                <include>libs/**</include>
+                                            </includes>
+                                            <filtering>false</filtering>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>backend</id>
+            <build>
+                <resources>
+                    <resource>
+                        <directory>src/main/resources</directory>
+                        <filtering>true</filtering>
+                    </resource>
+                </resources>
+                <testResources>
+                    <testResource>
+                        <directory>src/test/resources</directory>
+                    </testResource>
+                </testResources>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.8.0</version>
+                        <configuration>
+                            <release>11</release>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <finalName>DSMServer</finalName>
+                            <archive>
+                                <manifest>
+                                    <addClasspath>true</addClasspath>
+                                    <mainClass>org.broadinstitute.dsm.DSMServer</mainClass>
+                                    <classpathPrefix>lib/</classpathPrefix>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
         <testSourceDirectory>src/test/java</testSourceDirectory>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <filtering>true</filtering>
-            </resource>
-        </resources>
-        <testResources>
-            <testResource>
-                <directory>src/test/resources</directory>
-            </testResource>
-        </testResources>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
-                <configuration>
-                    <release>11</release>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <finalName>DSMServer</finalName>
-                    <archive>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                            <mainClass>org.broadinstitute.dsm.DSMServer</mainClass>
-                            <classpathPrefix>lib/</classpathPrefix>
-                        </manifest>
-                    </archive>
-                </configuration>
-            </plugin>
-        </plugins>
     </build>
 </project>
-
-<!-- arz remove ruby, postgress, activejdbc -->

--- a/src/main/java/org/broadinstitute/dsm/careevolve/Address.java
+++ b/src/main/java/org/broadinstitute/dsm/careevolve/Address.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsm.careevolve;
 
+import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 import org.apache.commons.lang3.StringUtils;
 
@@ -28,5 +29,13 @@ public class Address {
         this.city = city;
         this.state = state;
         this.zipCode = zipCode;
+    }
+
+    public static Address fromElasticAddress(JsonObject esAddress) {
+        return new Address(esAddress.get("street1").getAsString(),
+                esAddress.get("street2").getAsString(),
+                esAddress.get("city").getAsString(),
+                esAddress.get("state").getAsString(),
+                esAddress.get("zip").getAsString());
     }
 }

--- a/src/main/java/org/broadinstitute/dsm/careevolve/Covid19OrderRegistrar.java
+++ b/src/main/java/org/broadinstitute/dsm/careevolve/Covid19OrderRegistrar.java
@@ -10,6 +10,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
@@ -22,6 +23,8 @@ import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.exception.CareEvolveException;
 import org.broadinstitute.dsm.model.ParticipantWrapper;
 import org.broadinstitute.dsm.statics.DBConstants;
+import org.broadinstitute.dsm.util.ElasticSearchUtil;
+import org.elasticsearch.client.RestHighLevelClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +52,10 @@ public class Covid19OrderRegistrar {
 
     private final long retryWaitMillis;
 
+    private RestHighLevelClient esClient;
+
     public static final String BASELINE_COVID_ACTIVITY = "BASELINE_COVID";
+
     /**
      * Create a new one that uses the given endpoint
      * for placing orders
@@ -60,184 +66,78 @@ public class Covid19OrderRegistrar {
                                  int maxRetries,
                                  int retryWaitSeconds) {
         this.endpoint = endpoint;
-        this.careEvolveAccount  = careEvolveAccount;
+        this.careEvolveAccount = careEvolveAccount;
         this.provider = provider;
         this.maxRetries = maxRetries;
         this.retryWaitMillis = retryWaitSeconds * 1000;
     }
 
+    public OrderResponse orderTest(Authentication auth, Patient participant, String kitLabel, String kitId, Instant kitPickupTime) throws CareEvolveException {
+        String patientId = participant.getPatientId();
+        if (!(participant.hasFullName() && participant.hasDateOfBirth() && participant.hasAddress())) {
+            throw new CareEvolveException("Cannot place order with incomplete data for " + patientId);
+        }
+        List<AOE> aoes = AOE.forTestBoston(patientId, kitId);
+        Message message = new Message(new Order(careEvolveAccount, participant, kitLabel, kitPickupTime, provider, aoes), kitId);
+
+        OrderResponse orderResponse = null;
+
+        boolean orderSucceeded = false;
+        Collection<Exception> orderExceptions = new ArrayList<>();
+        int numAttempts = 0;
+        do {
+            try {
+                orderResponse = orderTest(auth, message);
+                orderSucceeded = true;
+                logger.info("Placed CE order {} {} for {}", orderResponse.getHandle(), orderResponse.getHl7Ack(), participant);
+            } catch (IOException e) {
+                orderExceptions.add(e);
+                logger.warn("Could not order test for " + patientId + ".  Pausing for " + retryWaitMillis + "ms before retry " + numAttempts + "/" + maxRetries, e);
+                try {
+                    Thread.sleep(retryWaitMillis);
+                } catch (InterruptedException interruptedException) {
+                    logger.error("Interrupted while waiting for CE order retry for patient " + patientId, e);
+                }
+            }
+            numAttempts++;
+        } while (numAttempts < maxRetries && !orderSucceeded);
+
+        if (!orderSucceeded) {
+            String exceptionsText = StringUtils.join(orderExceptions, "\n");
+            throw new CareEvolveException("Could not order test for " + patientId + " after " + maxRetries + ":\n" + exceptionsText);
+        }
+
+        if (StringUtils.isNotBlank(orderResponse.getError())) {
+            throw new CareEvolveException("Order for participant " + patientId + " with handle  " + orderResponse.getHandle() + " placed with error " + orderResponse.getError());
+        }
+        return orderResponse;
+    }
+
     /**
      * Places an order in CareEvolve
-     * @param auth the API credentials
+     *
+     * @param auth             the API credentials
      * @param participantHruid hruid for the participant
-     * @param kitLabel The label on the swab.  Corresponds to ORC-2 and GP sample_id
-     * @param kitId an identifier that will show up in Birch to help
-     *              associate the result back to the proper kit
-     * @param kitPickupTime the time at which the kit was picked
-     *                      up from the participant
+     * @param kitLabel         The label on the swab.  Corresponds to ORC-2 and GP sample_id
+     * @param kitId            an identifier that will show up in Birch to help
+     *                         associate the result back to the proper kit
+     * @param kitPickupTime    the time at which the kit was picked
+     *                         up from the participant
      */
-    public  OrderResponse orderTest(Authentication auth, String participantHruid, String kitLabel,
-                                          String kitId, Instant kitPickupTime) throws CareEvolveException {
+    public OrderResponse orderTest(Authentication auth, String participantHruid, String kitLabel,
+                                   String kitId, Instant kitPickupTime) throws CareEvolveException {
         if (kitPickupTime == null) {
             throw new CareEvolveException("Cannot place order for " + kitLabel + " without a pickup time");
         }
 
-        DDPInstance instance = DDPInstance.getDDPInstanceWithRole("testboston", DBConstants.HAS_KIT_REQUEST_ENDPOINTS);
+        DDPInstance ddpInstance = DDPInstance.getDDPInstanceWithRole("testboston", DBConstants.HAS_KIT_REQUEST_ENDPOINTS);
+        Map<String, Map<String, Object>> esData = ElasticSearchUtil.getSingleParticipantFromES(ddpInstance.getName(), ddpInstance.getParticipantIndexES(), esClient, participantHruid);
 
-        Map<String, String> queryConditions = new HashMap<>();
-        queryConditions.put("ES", " AND profile.hruid = '" + participantHruid +"'");
-        List<ParticipantWrapper> participants = ParticipantWrapper.getFilteredList(instance, queryConditions);
-
-        if (participants.size() == 1) {
-            ParticipantWrapper participant = participants.iterator().next();
-            JsonObject data = participant.getDataAsJson();
+        if (esData.size() == 1) {
+            JsonObject data = new JsonParser().parse(new Gson().toJson(esData.values().iterator().next())).getAsJsonObject();
             if (data != null) {
-                if (!data.has(ADDRESS_FIELD)) {
-                    throw new CareEvolveException("No address for " + participantHruid + ".  Cannot register order.");
-                }
-                JsonObject address = data.get(ADDRESS_FIELD).getAsJsonObject();
-                Address careEvolveAddress = toCareEvolveAddress(address);
-
-                JsonObject profile = data.get(PROFILE_FIELD).getAsJsonObject();
-                String patientId = profile.get(GUID_FIELD).getAsString();
-
-                String firstName = profile.get(FIRST_NAME_FIELD).getAsString();
-                String lastName = profile.get(LAST_NAME_FIELD).getAsString();
-
-                List<AOE> aoes = AOE.forTestBoston(patientId, kitId);
-
-                JsonArray activities = data.get(ACTIVITIES_FIELD).getAsJsonArray();
-
-                JsonObject baselineCovidActivity = getBaselineCovidActivity(activities);
-
-                JsonArray baselineCovidAnswers = baselineCovidActivity.get("questionsAnswers").getAsJsonArray();
-                String dob = null;
-
-                // mappings  for  race, ethnicity, and  sex are custom  for the  Ellkay API
-                // and are controlled  by the Ellkay integration
-                String race = "2131-1"; // code for "other"
-                String ethnicity = "U";
-                String sex = "U";
-                for (int i = 0; i < baselineCovidAnswers.size(); i++) {
-                    JsonObject answer = baselineCovidAnswers.get(i).getAsJsonObject();
-                    String questionStableId = answer.get("stableId").getAsString();
-
-                    if ("DOB".equals(questionStableId)) {
-                        JsonObject dateFields = answer.get("dateFields").getAsJsonObject();
-                        StringBuilder dobStr = new StringBuilder();
-                        dobStr.append(dateFields.get("year")).append("-")
-                                .append(dateFields.get("month")).append("-")
-                                .append(dateFields.get("day"));
-                        SimpleDateFormat dobFormat = new SimpleDateFormat("yyyy-MM-dd");
-                        try {
-                            dob = dobFormat.format(dobFormat.parse(dobStr.toString()));
-                        } catch (ParseException e) {
-                            throw new CareEvolveException("Could not parse dob " + dobStr.toString()
-                                    + " for participant " + patientId + " in activity instance " + baselineCovidActivity.get("guid"));
-                        }
-
-                    } else if ("SEX".equals(questionStableId)) {
-                        JsonArray sexAnswers = answer.getAsJsonArray(ANSWER_FIELD);
-                        if (sexAnswers.size() > 0) {
-                            sex = sexAnswers.get(0).getAsString();
-                        }
-
-                        if ("SEX_FEMALE".equals(sex)) {
-                            sex = "F";
-                        } else if ("SEX_MALE".equals(sex)) {
-                            sex = "M";
-                        } else if ("OTHER".equals(sex)) {
-                            sex = "U";
-                        } else {
-                            logger.error("Could not map sex " + sex + " to Ellkay code; will default to unknown for " + baselineCovidActivity.get("guid"));
-                        }
-
-                    } else if ("RACE".equals(questionStableId)) {
-                        JsonArray races = answer.getAsJsonArray(ANSWER_FIELD);
-
-                        if (races.size() == 1) {
-                            // CareEvolve only supports a  single race per order
-                            race = races.get(0).getAsString();
-
-                            if ("ASIAN".equals(race)) {
-                                race = "2028-9";
-                            } else if ("BLACK".equals(race)) {
-                                race = "2054-5";
-                            } else if ("AMERICAN_INDIAN".equals(race)) {
-                                race = "2054-5";
-                            } else if ("NATIVE_HAWAIIAN".equals(race)) {
-                                race = "2076-8";
-                            } else if ("WHITE".equals(race)) {
-                                race = "2106-3";
-                            } else if ("OTHER".equals(race)) {
-                                race = "2131-1";
-                            } else {
-                                logger.error("Could not map race " + race + " to Ellkay code; will default to other for " + baselineCovidActivity.get("guid"));
-                            }
-                        } else {
-                            // if there's no value or if multiple values are selected,
-                            // use the code for "other"
-                            race = "2131-1";
-                        }
-                    } else if ("ETHNICITY".equals(questionStableId)) {
-                        JsonArray answers = answer.getAsJsonArray(ANSWER_FIELD);
-                        if (answers.size() > 0) {
-                            ethnicity = answer.getAsJsonArray(ANSWER_FIELD).get(0).getAsString();
-                            if ("HISPANIC_LATINO".equals(ethnicity)) {
-                                ethnicity = "H";
-                            } else if ("NOT_HISPANIC_LATINO".equals(ethnicity)) {
-                                ethnicity = "N";
-                            } else {
-                                logger.error("Could not map ethnicity " + ethnicity + " to Ellkay code; will default to unknown for " + baselineCovidActivity.get("guid"));
-                            }
-                        }
-                    }
-                }
-
-                if (StringUtils.isBlank(firstName)) {
-                    throw new CareEvolveException("Cannot place order for " + kitLabel + " without first name");
-                }
-
-                if (StringUtils.isBlank(lastName)) {
-                    throw new CareEvolveException("Cannot place order for " + kitLabel + " without last name");
-                }
-
-                Patient testPatient = new Patient(patientId, firstName, lastName, dob, race, ethnicity,
-                        sex, careEvolveAddress);
-
-                Message message = new Message(new Order(careEvolveAccount, testPatient, kitLabel, kitPickupTime, provider, aoes), kitId);
-
-                OrderResponse orderResponse = null;
-
-                boolean orderSucceeded = false;
-                Collection<Exception> orderExceptions = new ArrayList<>();
-                int numAttempts = 0;
-                do {
-                    try {
-                        orderResponse = orderTest(auth, message);
-                        orderSucceeded = true;
-                        logger.info("Placed CE order {} {} for {}", orderResponse.getHandle(), orderResponse.getHl7Ack(), patientId);
-                    } catch (IOException e) {
-                        orderExceptions.add(e);
-                        logger.warn("Could not order test for " + patientId + ".  Pausing for " + retryWaitMillis + "ms before retry " + numAttempts + "/" + maxRetries, e);
-                        try {
-                            Thread.sleep(retryWaitMillis);
-                        } catch (InterruptedException interruptedException) {
-                            logger.error("Interrupted while waiting for CE order retry for patient " + patientId, e);
-                        }
-                    }
-                    numAttempts++;
-                } while (numAttempts < maxRetries && !orderSucceeded);
-
-                if (!orderSucceeded) {
-                    String exceptionsText = StringUtils.join(orderExceptions, "\n");
-                    throw new CareEvolveException("Could not order test for " + patientId + " after " + maxRetries + ":\n" + exceptionsText);
-                }
-
-                if (StringUtils.isNotBlank(orderResponse.getError())) {
-                    throw new CareEvolveException("Order for participant " + participantHruid + " with handle  " + orderResponse.getHandle() + " placed with error " + orderResponse.getError());
-                }
-                return orderResponse;
+                Patient patient = fromElasticData(data);
+                return orderTest(auth, patient, kitLabel, kitId, kitPickupTime);
             } else {
                 throw new CareEvolveException("No participant data for " + participantHruid + ".  Cannot register order.");
             }
@@ -246,7 +146,7 @@ public class Covid19OrderRegistrar {
         }
     }
 
-    private JsonObject getBaselineCovidActivity(JsonArray activities) {
+    public static JsonObject getBaselineCovidActivity(JsonArray activities) {
         JsonObject baselineCovidActivity = null;
         for (int i = 0; i < activities.size(); i++) {
             JsonObject activity = activities.get(i).getAsJsonObject();
@@ -255,14 +155,6 @@ public class Covid19OrderRegistrar {
             }
         }
         return baselineCovidActivity;
-    }
-
-    private Address toCareEvolveAddress(JsonObject esAddress) {
-        return new Address(esAddress.get("street1").getAsString(),
-                esAddress.get("street2").getAsString(),
-                esAddress.get("city").getAsString(),
-                esAddress.get("state").getAsString(),
-                esAddress.get("zip").getAsString());
     }
 
     /**
@@ -288,5 +180,111 @@ public class Covid19OrderRegistrar {
             logger.error("Order {} returned {} with {}", message.getName(), httpResponse.getStatusLine().getStatusCode(), responseString);
             throw new CareEvolveException("CareEvolve returned " + httpResponse.getStatusLine().getStatusCode() + " with " + responseString);
         }
+    }
+
+    public static Patient fromElasticData(JsonObject data) {
+        Patient patient;
+        if (data != null) {
+            JsonObject address = data.get(ADDRESS_FIELD).getAsJsonObject();
+            Address careEvolveAddress = Address.fromElasticAddress(address);
+
+            JsonObject profile = data.get(PROFILE_FIELD).getAsJsonObject();
+            String patientId = profile.get(GUID_FIELD).getAsString();
+
+            String firstName = profile.get(FIRST_NAME_FIELD).getAsString();
+            String lastName = profile.get(LAST_NAME_FIELD).getAsString();
+
+            JsonArray activities = data.get(ACTIVITIES_FIELD).getAsJsonArray();
+
+            JsonObject baselineCovidActivity = Covid19OrderRegistrar.getBaselineCovidActivity(activities);
+
+            JsonArray baselineCovidAnswers = baselineCovidActivity.get("questionsAnswers").getAsJsonArray();
+            String dob = null;
+
+            // mappings  for  race, ethnicity, and  sex are custom  for the  Ellkay API
+            // and are controlled  by the Ellkay integration
+            String race = "2131-1"; // code for "other"
+            String ethnicity = "U";
+            String sex = "U";
+            for (int i = 0; i < baselineCovidAnswers.size(); i++) {
+                JsonObject answer = baselineCovidAnswers.get(i).getAsJsonObject();
+                String questionStableId = answer.get("stableId").getAsString();
+
+                if ("DOB".equals(questionStableId)) {
+                    JsonObject dateFields = answer.get("dateFields").getAsJsonObject();
+                    StringBuilder dobStr = new StringBuilder();
+                    dobStr.append(dateFields.get("year")).append("-")
+                            .append(dateFields.get("month")).append("-")
+                            .append(dateFields.get("day"));
+                    SimpleDateFormat dobFormat = new SimpleDateFormat("yyyy-MM-dd");
+                    try {
+                        dob = dobFormat.format(dobFormat.parse(dobStr.toString()));
+                    } catch (ParseException e) {
+                        throw new CareEvolveException("Could not parse dob " + dobStr.toString()
+                                + " for participant " + patientId + " in activity instance " + baselineCovidActivity.get("guid"));
+                    }
+
+                } else if ("SEX".equals(questionStableId)) {
+                    JsonArray sexAnswers = answer.getAsJsonArray(ANSWER_FIELD);
+                    if (sexAnswers.size() > 0) {
+                        sex = sexAnswers.get(0).getAsString();
+                    }
+
+                    if ("SEX_FEMALE".equals(sex)) {
+                        sex = "F";
+                    } else if ("SEX_MALE".equals(sex)) {
+                        sex = "M";
+                    } else if ("OTHER".equals(sex)) {
+                        sex = "U";
+                    } else {
+                        logger.error("Could not map sex " + sex + " to Ellkay code; will default to unknown for " + baselineCovidActivity.get("guid"));
+                    }
+
+                } else if ("RACE".equals(questionStableId)) {
+                    JsonArray races = answer.getAsJsonArray(ANSWER_FIELD);
+
+                    if (races.size() == 1) {
+                        // CareEvolve only supports a  single race per order
+                        race = races.get(0).getAsString();
+
+                        if ("ASIAN".equals(race)) {
+                            race = "2028-9";
+                        } else if ("BLACK".equals(race)) {
+                            race = "2054-5";
+                        } else if ("AMERICAN_INDIAN".equals(race)) {
+                            race = "2054-5";
+                        } else if ("NATIVE_HAWAIIAN".equals(race)) {
+                            race = "2076-8";
+                        } else if ("WHITE".equals(race)) {
+                            race = "2106-3";
+                        } else if ("OTHER".equals(race)) {
+                            race = "2131-1";
+                        } else {
+                            logger.error("Could not map race " + race + " to Ellkay code; will default to other for " + baselineCovidActivity.get("guid"));
+                        }
+                    } else {
+                        // if there's no value or if multiple values are selected,
+                        // use the code for "other"
+                        race = "2131-1";
+                    }
+                } else if ("ETHNICITY".equals(questionStableId)) {
+                    JsonArray answers = answer.getAsJsonArray(ANSWER_FIELD);
+                    if (answers.size() > 0) {
+                        ethnicity = answer.getAsJsonArray(ANSWER_FIELD).get(0).getAsString();
+                        if ("HISPANIC_LATINO".equals(ethnicity)) {
+                            ethnicity = "H";
+                        } else if ("NOT_HISPANIC_LATINO".equals(ethnicity)) {
+                            ethnicity = "N";
+                        } else {
+                            logger.error("Could not map ethnicity " + ethnicity + " to Ellkay code; will default to unknown for " + baselineCovidActivity.get("guid"));
+                        }
+                    }
+                }
+            }
+            patient = new Patient(patientId, firstName, lastName, dob, race, ethnicity, sex, careEvolveAddress);
+        } else {
+            throw new IllegalArgumentException("data must be non-null");
+        }
+        return patient;
     }
 }

--- a/src/main/java/org/broadinstitute/dsm/careevolve/OrderResponse.java
+++ b/src/main/java/org/broadinstitute/dsm/careevolve/OrderResponse.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsm.careevolve;
 
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.StringUtils;
 
 public class OrderResponse {
 
@@ -23,5 +24,9 @@ public class OrderResponse {
 
     public String getError() {
         return error;
+    }
+
+    public boolean hasError() {
+        return StringUtils.isNotBlank(error);
     }
 }

--- a/src/main/java/org/broadinstitute/dsm/careevolve/Patient.java
+++ b/src/main/java/org/broadinstitute/dsm/careevolve/Patient.java
@@ -1,6 +1,23 @@
 package org.broadinstitute.dsm.careevolve;
 
+import static org.broadinstitute.dsm.careevolve.Covid19OrderRegistrar.ACTIVITIES_FIELD;
+import static org.broadinstitute.dsm.careevolve.Covid19OrderRegistrar.ADDRESS_FIELD;
+import static org.broadinstitute.dsm.careevolve.Covid19OrderRegistrar.ANSWER_FIELD;
+import static org.broadinstitute.dsm.careevolve.Covid19OrderRegistrar.FIRST_NAME_FIELD;
+import static org.broadinstitute.dsm.careevolve.Covid19OrderRegistrar.GUID_FIELD;
+import static org.broadinstitute.dsm.careevolve.Covid19OrderRegistrar.LAST_NAME_FIELD;
+import static org.broadinstitute.dsm.careevolve.Covid19OrderRegistrar.PROFILE_FIELD;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.dsm.exception.CareEvolveException;
 
 public class Patient {
 
@@ -46,5 +63,35 @@ public class Patient {
         this.ethnicity = ethnicity;
         this.gender = gender;
         this.address = address;
+    }
+
+    public String getPatientId() {
+        return patientId;
+    }
+
+    public boolean hasFullName() {
+        return StringUtils.isNotBlank(firstName) && StringUtils.isNotBlank(lastName);
+    }
+
+    public boolean hasDateOfBirth() {
+        return StringUtils.isNotBlank(dateOfBirth);
+    }
+
+    public boolean hasAddress() {
+        return address != null;
+    }
+
+    @Override
+    public String toString() {
+        return "Patient{" +
+                "patientId='" + patientId + '\'' +
+                ", lastName='" + lastName + '\'' +
+                ", firstName='" + firstName + '\'' +
+                ", dateOfBirth='" + dateOfBirth + '\'' +
+                ", race='" + race + '\'' +
+                ", ethnicity='" + ethnicity + '\'' +
+                ", gender='" + gender + '\'' +
+                ", address=" + address +
+                '}';
     }
 }

--- a/src/main/java/org/broadinstitute/dsm/cf/BaseCloudFunctionPayload.java
+++ b/src/main/java/org/broadinstitute/dsm/cf/BaseCloudFunctionPayload.java
@@ -1,0 +1,17 @@
+package org.broadinstitute.dsm.cf;
+
+import java.util.Map;
+
+import com.google.gson.annotations.SerializedName;
+
+public abstract class BaseCloudFunctionPayload {
+
+    @SerializedName("attributes")
+    Map<String, String> attributes;
+
+    @SerializedName("messageId")
+    String messageId;
+
+    @SerializedName("publishTime")
+    String publishTime;
+}

--- a/src/main/java/org/broadinstitute/dsm/cf/CFUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/cf/CFUtil.java
@@ -1,0 +1,60 @@
+package org.broadinstitute.dsm.cf;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretPayload;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.apache.commons.dbcp2.ConnectionFactory;
+import org.apache.commons.dbcp2.DriverManagerConnectionFactory;
+import org.apache.commons.dbcp2.PoolableConnection;
+import org.apache.commons.dbcp2.PoolableConnectionFactory;
+import org.apache.commons.dbcp2.PoolingDataSource;
+import org.apache.commons.pool2.ObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+public class CFUtil {
+
+    private static final Logger logger = Logger.getLogger(CFUtil.class.getName());
+
+    // todo centralize this for stateless db connections.  statics in cloud functions
+    // can be shared across invocations, making things like TransactionWrapper.init() hard to predict.
+    public static PoolingDataSource<PoolableConnection> createDataSource(int maxConnections, String dbUrl) {
+        ConnectionFactory connectionFactory = new DriverManagerConnectionFactory(dbUrl, null);
+        PoolableConnectionFactory poolableConnectionFactory = new PoolableConnectionFactory(connectionFactory, null);
+        poolableConnectionFactory.setDefaultAutoCommit(false);
+        GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
+        poolConfig.setMaxTotal(maxConnections);
+        poolConfig.setTestOnBorrow(false);
+        poolConfig.setBlockWhenExhausted(false);
+        poolConfig.setTestWhileIdle(true);
+        poolConfig.setMinIdle(5);
+        poolConfig.setMinEvictableIdleTimeMillis(60000L);
+        poolableConnectionFactory.setValidationQueryTimeout(1);
+        ObjectPool<PoolableConnection> connectionPool = new GenericObjectPool(poolableConnectionFactory, poolConfig);
+        poolableConnectionFactory.setPool(connectionPool);
+        PoolingDataSource<PoolableConnection> dataSource = new PoolingDataSource(connectionPool);
+        return dataSource;
+    }
+
+    public static Config loadConfig(String projectId, String secretId) throws IOException  {
+        logger.info("Looking up secrets from project " + projectId + " and secret " + secretId);
+        try (SecretManagerServiceClient secretManagerServiceClient = SecretManagerServiceClient.create()) {
+            var latestSecretVersion = SecretVersionName.of(projectId, secretId, "latest");
+            SecretPayload secret = secretManagerServiceClient.accessSecretVersion(latestSecretVersion).getPayload();
+            String secretData = secret.getData().toStringUtf8();
+            return ConfigFactory.parseString(secretData);
+        }
+    }
+
+    public static Config loadConfig() throws IOException {
+        String projectId = System.getenv("PROJECT_ID");
+        String secretId = System.getenv("SECRET_ID");
+
+        return loadConfig(projectId, secretId);
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/cf/Covid19OrderRegistrarFunction.java
+++ b/src/main/java/org/broadinstitute/dsm/cf/Covid19OrderRegistrarFunction.java
@@ -1,0 +1,152 @@
+package org.broadinstitute.dsm.cf;
+
+import static org.broadinstitute.dsm.statics.ApplicationConfigConstants.DSM_DB_URL;
+
+import java.sql.Connection;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.google.cloud.functions.BackgroundFunction;
+import com.google.cloud.functions.Context;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.annotations.SerializedName;
+import com.google.pubsub.v1.PubsubMessage;
+import com.typesafe.config.Config;
+import org.apache.commons.dbcp2.PoolableConnection;
+import org.apache.commons.dbcp2.PoolingDataSource;
+import org.broadinstitute.dsm.careevolve.Authentication;
+import org.broadinstitute.dsm.careevolve.Covid19OrderRegistrar;
+import org.broadinstitute.dsm.careevolve.OrderResponse;
+import org.broadinstitute.dsm.careevolve.Patient;
+import org.broadinstitute.dsm.careevolve.Provider;
+import org.broadinstitute.dsm.db.DDPInstance;
+import org.broadinstitute.dsm.db.DdpKit;
+import org.broadinstitute.dsm.statics.ApplicationConfigConstants;
+import org.broadinstitute.dsm.statics.DBConstants;
+import org.broadinstitute.dsm.util.ElasticSearchUtil;
+import org.elasticsearch.client.RestHighLevelClient;
+
+public class Covid19OrderRegistrarFunction  implements BackgroundFunction<Covid19OrderRegistrarFunction.OrderPayload> {
+
+    private static final Logger logger = Logger.getLogger(TestBostonKitTrackerDispatcher.class.getName());
+
+    @Override
+    public void accept(OrderPayload orderPayload, Context context) throws Exception {
+        logger.info("Processing request " + orderPayload);
+        // check first to see if it's already ordered.
+
+        Config cfg = CFUtil.loadConfig();
+        String careEvolveAccount = cfg.getString(ApplicationConfigConstants.CARE_EVOLVE_ACCOUNT);
+        String careEvolveSubscriberKey = cfg.getString(ApplicationConfigConstants.CARE_EVOLVE_SUBSCRIBER_KEY);
+        String careEvolveServiceKey = cfg.getString(ApplicationConfigConstants.CARE_EVOLVE_SERVICE_KEY);
+        String careEvolveOrderEndpoint = cfg.getString(ApplicationConfigConstants.CARE_EVOLVE_ORDER_ENDPOINT);
+        Authentication auth = new Authentication(careEvolveSubscriberKey, careEvolveServiceKey);
+        Provider provider = new Provider(cfg.getString(ApplicationConfigConstants.CARE_EVOLVE_PROVIDER_FIRSTNAME),
+                cfg.getString(ApplicationConfigConstants.CARE_EVOLVE_PROVIDER_LAST_NAME),
+                cfg.getString(ApplicationConfigConstants.CARE_EVOLVE_PROVIDER_NPI));
+
+        PoolingDataSource<PoolableConnection> dataSource = CFUtil.createDataSource(5, cfg.getString(DSM_DB_URL));
+
+        DDPInstance ddpInstance = null;
+
+        try (Connection conn = dataSource.getConnection()) {
+            ddpInstance = DDPInstance.getDDPInstanceWithRole(conn,"testboston", DBConstants.HAS_KIT_REQUEST_ENDPOINTS);
+            logger.info("Will use instance " + ddpInstance.getName());
+
+            if (DdpKit.hasKitBeenOrderedInCE(conn, orderPayload.getExternalOrderId())) {
+                logger.log(Level.WARNING, orderPayload.getKitLabel() + " has already been ordered in CE");
+                return;
+            }
+        }
+
+        String esUrl = cfg.getString(ApplicationConfigConstants.ES_URL);
+        String esUsername = cfg.getString(ApplicationConfigConstants.ES_USERNAME);
+        String esPassword = cfg.getString(ApplicationConfigConstants.ES_PASSWORD);
+        String esProxy = cfg.getString(ApplicationConfigConstants.ES_PROXY);
+        RestHighLevelClient esClient = ElasticSearchUtil.getClientForElasticsearchCloud(esUrl, esUsername, esPassword, esProxy);
+
+        Covid19OrderRegistrar orderRegistrar = new Covid19OrderRegistrar(careEvolveOrderEndpoint, careEvolveAccount, provider, 0, 0);
+
+        Map<String, Map<String, Object>> esData = ElasticSearchUtil.getSingleParticipantFromES(ddpInstance.getName(), ddpInstance.getParticipantIndexES(), esClient, orderPayload.getParticipantHruid());
+
+        if (esData.size() == 1) {
+            JsonObject participantJsonData = new JsonParser().parse(new Gson().toJson(esData.values().iterator().next())).getAsJsonObject();
+            Patient cePatient = Covid19OrderRegistrar.fromElasticData(participantJsonData);
+            System.out.println(cePatient);
+
+            OrderResponse orderResponse = orderRegistrar.orderTest(auth, cePatient, orderPayload.getKitLabel(), orderPayload.getExternalOrderId(), orderPayload.getCollectionTime());
+
+            if (orderResponse.hasError()) {
+                logger.log(Level.SEVERE, "Trouble placing order for " + orderPayload.getKitLabel() + ":" + orderResponse.getError());
+            } else {
+                logger.info(orderPayload.getKitLabel() + " has been placed for " + orderPayload.getParticipantHruid() + ".  CE id is " + orderResponse.getHandle());
+                try (Connection conn = dataSource.getConnection()) {
+                    DdpKit.updateCEOrdered(conn, true, orderPayload.getExternalOrderId());
+                }
+            }
+        } else {
+            throw new RuntimeException("Could not find es data for " + orderPayload.getParticipantHruid());
+        }
+    }
+
+    public static class OrderPayload extends BaseCloudFunctionPayload {
+
+        @SerializedName("hruid")
+        private String participantHruid;
+
+        // yyyy-MM-dd hh:mm, US/NY timezone
+        @SerializedName("collectionTime")
+        private String collectionTime;
+
+        @SerializedName("kitLabel")
+        private String kitLabel;
+
+        @SerializedName("externalOrderId")
+        private String externalOrderId;
+
+        public String getParticipantHruid() {
+            return participantHruid;
+        }
+
+        public String getRawCollectionTime() {
+            return collectionTime;
+        }
+
+        public String getKitLabel() {
+            return kitLabel;
+        }
+
+        public String getExternalOrderId() {
+            return externalOrderId;
+        }
+
+        public Instant getCollectionTime() {
+            Instant collectionInstant = null;
+            try {
+                var dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm");
+                dateFormat.setTimeZone(TimeZone.getTimeZone("America/New_York"));
+                collectionInstant =  dateFormat.parse(collectionTime).toInstant();
+            } catch(ParseException e) {
+                throw new RuntimeException("Could not parse " + collectionTime + " for " + kitLabel, e);
+            }
+            return collectionInstant;
+        }
+
+        @Override
+        public String toString() {
+            return "OrderPayload{" +
+                    "participantHruid='" + participantHruid + '\'' +
+                    ", collectionTime='" + collectionTime + '\'' +
+                    ", kitLabel='" + kitLabel + '\'' +
+                    ", externalOrderId='" + externalOrderId + '\'' +
+                    '}';
+        }
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/cf/Covid19OrderRegistrarFunction.java
+++ b/src/main/java/org/broadinstitute/dsm/cf/Covid19OrderRegistrarFunction.java
@@ -60,7 +60,7 @@ public class Covid19OrderRegistrarFunction  implements BackgroundFunction<Covid1
             ddpInstance = DDPInstance.getDDPInstanceWithRole(conn,"testboston", DBConstants.HAS_KIT_REQUEST_ENDPOINTS);
             logger.info("Will use instance " + ddpInstance.getName());
 
-            if (DdpKit.hasKitBeenOrderedInCE(conn, orderPayload.getExternalOrderId())) {
+            if (DdpKit.hasKitBeenOrderedInCE(conn, orderPayload.getKitLabel())) {
                 logger.log(Level.WARNING, orderPayload.getKitLabel() + " has already been ordered in CE");
                 return;
             }
@@ -88,7 +88,7 @@ public class Covid19OrderRegistrarFunction  implements BackgroundFunction<Covid1
             } else {
                 logger.info(orderPayload.getKitLabel() + " has been placed for " + orderPayload.getParticipantHruid() + ".  CE id is " + orderResponse.getHandle());
                 try (Connection conn = dataSource.getConnection()) {
-                    DdpKit.updateCEOrdered(conn, true, orderPayload.getExternalOrderId());
+                    DdpKit.updateCEOrdered(conn, true, orderPayload.getKitLabel());
                 }
             }
         } else {

--- a/src/main/java/org/broadinstitute/dsm/cf/TestBostonKitTrackerDispatcher.java
+++ b/src/main/java/org/broadinstitute/dsm/cf/TestBostonKitTrackerDispatcher.java
@@ -1,0 +1,134 @@
+package org.broadinstitute.dsm.cf;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.google.cloud.functions.BackgroundFunction;
+import com.google.cloud.functions.Context;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretPayload;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
+import com.google.pubsub.v1.PubsubMessage;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.apache.commons.dbcp2.ConnectionFactory;
+import org.apache.commons.dbcp2.DriverManagerConnectionFactory;
+import org.apache.commons.dbcp2.PoolableConnection;
+import org.apache.commons.dbcp2.PoolableConnectionFactory;
+import org.apache.commons.dbcp2.PoolingDataSource;
+import org.apache.commons.pool2.ObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+/**
+ * Identifies kits whose shipping history should be
+ * queried (by another job) in order to produce
+ * reports on turnaround time and study adherence.
+ */
+public class TestBostonKitTrackerDispatcher implements BackgroundFunction<PubsubMessage> {
+
+    private static final Logger logger = Logger.getLogger(TestBostonKitTrackerDispatcher.class.getName());
+
+    private String STUDY_MANAGER_SCHEMA = System.getenv("STUDY_MANAGER_SCHEMA") + ".";
+    private String STUDY_SERVER_SCHEMA = System.getenv("STUDY_SERVER_SCHEMA") + ".";
+
+
+    @Override
+    public void accept(PubsubMessage pubsubMessage, Context context) throws Exception {
+        String projectId = System.getenv("PROJECT_ID");
+        String secretId = System.getenv("SECRET_ID");
+
+
+        String KIT_QUERY =
+                "select\n" +
+                "u.guid,\n" +
+                "k.kit_label,\n" +
+                "from_unixtime(dkr.created_date/1000) as kit_requested_at,\n" +
+                "k.tracking_to_id,\n" +
+                "k.tracking_return_id,\n" +
+                "json_extract(k.test_result, '$[0].result') test_result,\n" +
+                "ifnull(STR_TO_DATE(replace(json_extract(k.test_result, '$[0].timeCompleted'),'\"',''), '%Y-%m-%dT%H:%i:%sZ'),\n" +
+                "    STR_TO_DATE(replace(json_extract(k.test_result, '$[0].timeCompleted'),'\"',''), '%Y-%m-%dT%H:%i:%s.%fZ')\n" +
+                ")as test_completion_time,\n" +
+                "u.hruid,\n" +
+                "dkr.upload_reason\n" +
+                "from\n" +
+                STUDY_MANAGER_SCHEMA + "ddp_kit k,\n" +
+                STUDY_MANAGER_SCHEMA + "ddp_kit_request dkr,\n" +
+                STUDY_SERVER_SCHEMA + "user u,\n" +
+                STUDY_MANAGER_SCHEMA + "ddp_instance study,\n" +
+                STUDY_MANAGER_SCHEMA + "kit_type kt\n" +
+                "where\n" +
+                "study.instance_name = 'testboston'\n" +
+                "and\n" +
+                "u.guid = dkr.ddp_participant_id\n" +
+                "and\n" +
+                "study.ddp_instance_id = dkr.ddp_instance_id\n" +
+                "and\n" +
+                "dkr.dsm_kit_request_id = k.dsm_kit_request_id\n" +
+                "and\n" +
+                "kt.kit_type_id = dkr.kit_type_id\n" +
+                "and\n" +
+                "kt.kit_type_name = 'AN'\n" +
+                "and k.kit_label like 'TBOS-%'\n" +
+                "order by test_completion_time";
+
+
+        logger.info("Starting up in project " + projectId + " and secret " + secretId);
+        Config cfg = null;
+
+        try (SecretManagerServiceClient secretManagerServiceClient = SecretManagerServiceClient.create()) {
+            var latestSecretVersion = SecretVersionName.of(projectId, secretId, "latest");
+            SecretPayload secret = secretManagerServiceClient.accessSecretVersion(latestSecretVersion).getPayload();
+            String secretData = secret.getData().toStringUtf8();
+            cfg = ConfigFactory.parseString(secretData);
+        }
+        String dbUrl = cfg.getString("pepperDbUrl");
+
+        PoolingDataSource<PoolableConnection> dataSource = createDataSource(1, dbUrl);
+
+        // static vars are dangerous in CF https://cloud.google.com/functions/docs/bestpractices/tips#functions-tips-scopes-java
+        try (Connection conn = dataSource.getConnection()) {
+            try (PreparedStatement stmt = conn.prepareStatement(KIT_QUERY)) {
+                stmt.setFetchSize(1000);
+                try (ResultSet rs = stmt.executeQuery()) {
+                    while (rs.next()) {
+                        String userGuid = rs.getString("guid");
+                        logger.info(userGuid);
+
+                        // spawn threads or other cloud functions in fixed size blocks? Write to a separate queue for worker threads
+                        // to grab history?
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            logger.log(Level.SEVERE, "Trouble querying data", e);
+        }
+    }
+
+    // todo centralize this for stateless db connections.  statics in cloud functions
+    // can be shared across invocations, making things like TransactionWrapper.init() hard to predict.
+    private PoolingDataSource<PoolableConnection> createDataSource(int maxConnections, String dbUrl) {
+        ConnectionFactory connectionFactory = new DriverManagerConnectionFactory(dbUrl, null);
+        PoolableConnectionFactory poolableConnectionFactory = new PoolableConnectionFactory(connectionFactory, null);
+        poolableConnectionFactory.setDefaultAutoCommit(false);
+        GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
+        poolConfig.setMaxTotal(maxConnections);
+        poolConfig.setTestOnBorrow(false);
+        poolConfig.setBlockWhenExhausted(false);
+        poolConfig.setTestWhileIdle(true);
+        poolConfig.setMinIdle(5);
+        poolConfig.setMinEvictableIdleTimeMillis(60000L);
+        poolableConnectionFactory.setValidationQueryTimeout(1);
+        ObjectPool<PoolableConnection> connectionPool = new GenericObjectPool(poolableConnectionFactory, poolConfig);
+        poolableConnectionFactory.setPool(connectionPool);
+        PoolingDataSource<PoolableConnection> dataSource = new PoolingDataSource(connectionPool);
+        return dataSource;
+    }
+
+
+}

--- a/src/main/java/org/broadinstitute/dsm/db/DDPInstance.java
+++ b/src/main/java/org/broadinstitute/dsm/db/DDPInstance.java
@@ -11,6 +11,7 @@ import org.broadinstitute.dsm.statics.QueryExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -170,33 +171,26 @@ public class DDPInstance {
         return (String) results.resultValue;
     }
 
-
-
     public static DDPInstance getDDPInstanceWithRole(@NonNull String realm, @NonNull String role) {
-        SimpleResult results = inTransaction((conn) -> {
-            SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement stmt = conn.prepareStatement(SQL_SELECT_INSTANCE_WITH_ROLE + QueryExtension.BY_INSTANCE_NAME)) {
-                stmt.setString(1, role);
-                stmt.setString(2, realm);
-                try (ResultSet rs = stmt.executeQuery()) {
-                    if (rs.next()) {
-                        dbVals.resultValue = getDDPInstanceWithRoleFormResultSet(rs);
-                    }
-                }
-                catch (SQLException e) {
-                    throw new RuntimeException("Error getting list of ddps ", e);
-                }
-            }
-            catch (SQLException ex) {
-                dbVals.resultException = ex;
-            }
-            return dbVals;
+        return inTransaction((conn) -> {
+            return getDDPInstanceWithRole(conn, realm, role);
         });
+    }
 
-        if (results.resultException != null) {
-            throw new RuntimeException("Couldn't get list of ddps ", results.resultException);
+    public static DDPInstance getDDPInstanceWithRole(@NonNull Connection conn, @NonNull String realm, @NonNull String role) {
+        DDPInstance instance = null;
+        try (PreparedStatement stmt = conn.prepareStatement(SQL_SELECT_INSTANCE_WITH_ROLE + QueryExtension.BY_INSTANCE_NAME)) {
+            stmt.setString(1, role);
+            stmt.setString(2, realm);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    instance = getDDPInstanceWithRoleFormResultSet(rs);
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Error getting list of ddps ", e);
         }
-        return (DDPInstance) results.resultValue;
+        return instance;
     }
 
     public static String getDDPGroupId(@NonNull String realm) {

--- a/src/main/java/org/broadinstitute/dsm/jobs/TestBostonUPSTrackingJob.java
+++ b/src/main/java/org/broadinstitute/dsm/jobs/TestBostonUPSTrackingJob.java
@@ -11,6 +11,7 @@ import org.broadinstitute.dsm.model.KitDDPNotification;
 import org.broadinstitute.dsm.model.ups.*;
 import org.broadinstitute.dsm.shipping.UPSTracker;
 import org.broadinstitute.dsm.statics.DBConstants;
+import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.EventUtil;
 import org.broadinstitute.dsm.util.KitUtil;
 import org.quartz.Job;

--- a/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
@@ -69,13 +69,26 @@ public class ElasticSearchUtil {
     public static final String STATUS = "status";
     public static final String PROFILE_CREATED_AT = "profile." + CREATED_AT;
 
-    public static RestHighLevelClient getClientForElasticsearchCloud(@NonNull String baseUrl, @NonNull String userName, @NonNull String password) throws MalformedURLException {
+    public static RestHighLevelClient getClientForElasticsearchCloud(@NonNull String baseUrl,
+                                                                     @NonNull String userName,
+                                                                     @NonNull String password) throws MalformedURLException {
         final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(userName, password));
 
         URL url = new URL(baseUrl);
         String proxy = TransactionWrapper.hasConfigPath(ApplicationConfigConstants.ES_PROXY)
                 ? TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.ES_PROXY) : null;
+        return getClientForElasticsearchCloud(baseUrl, userName, password, proxy);
+    }
+
+    public static RestHighLevelClient getClientForElasticsearchCloud(@NonNull String baseUrl,
+                                                                     @NonNull String userName,
+                                                                     @NonNull String password,
+                                                                     String proxy) throws MalformedURLException {
+        final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(userName, password));
+
+        URL url = new URL(baseUrl);
         URL proxyUrl = (proxy != null && !proxy.isBlank()) ? new URL(proxy) : null;
         if (proxyUrl != null) {
             logger.info("Using Elasticsearch client proxy: {}", proxyUrl);
@@ -94,6 +107,70 @@ public class ElasticSearchUtil {
         return new RestHighLevelClient(builder);
     }
 
+    public static Map<String, Map<String, Object>> getSingleParticipantFromES(@NonNull String realm,
+                                                                            @NonNull String index,
+                                                                            RestHighLevelClient client,
+                                                                              String participantHruid) {
+        Map<String, Map<String, Object>> esData = new HashMap<>();
+        if (StringUtils.isNotBlank(index)) {
+            logger.info("Collecting ES data");
+            try {
+                int scrollSize = 1000;
+                SearchRequest searchRequest = new SearchRequest(index);
+                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+                SearchResponse response = null;
+                int i = 0;
+                searchSourceBuilder.query(QueryBuilders.matchQuery("profile.hruid", participantHruid)).sort(PROFILE_CREATED_AT, SortOrder.ASC);
+                while (response == null || response.getHits().getHits().length != 0) {
+                    searchSourceBuilder.size(scrollSize);
+                    searchSourceBuilder.from(i * scrollSize);
+                    searchRequest.source(searchSourceBuilder);
+
+                    response = client.search(searchRequest, RequestOptions.DEFAULT);
+                    addingParticipantStructuredHits(response, esData, realm);
+                    i++;
+                }
+            }
+            catch (Exception e) {
+                throw new RuntimeException("Couldn't get participants from ES for instance " + realm, e);
+            }
+            logger.info("Got " + esData.size() + " participants from ES for instance " + realm);
+        }
+        return esData;
+    }
+
+
+    public static Map<String, Map<String, Object>> getDDPParticipantsFromES(@NonNull String realm,
+                                                                            @NonNull String index,
+                                                                            RestHighLevelClient client) {
+        Map<String, Map<String, Object>> esData = new HashMap<>();
+        if (StringUtils.isNotBlank(index)) {
+            logger.info("Collecting ES data");
+            try {
+                int scrollSize = 1000;
+                SearchRequest searchRequest = new SearchRequest(index);
+                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+                SearchResponse response = null;
+                int i = 0;
+                searchSourceBuilder.query(QueryBuilders.matchAllQuery()).sort(PROFILE_CREATED_AT, SortOrder.ASC);
+                while (response == null || response.getHits().getHits().length != 0) {
+                    searchSourceBuilder.size(scrollSize);
+                    searchSourceBuilder.from(i * scrollSize);
+                    searchRequest.source(searchSourceBuilder);
+
+                    response = client.search(searchRequest, RequestOptions.DEFAULT);
+                    addingParticipantStructuredHits(response, esData, realm);
+                    i++;
+                }
+            }
+            catch (Exception e) {
+                throw new RuntimeException("Couldn't get participants from ES for instance " + realm, e);
+            }
+            logger.info("Got " + esData.size() + " participants from ES for instance " + realm);
+        }
+        return esData;
+    }
+
     public static Map<String, Map<String, Object>> getDDPParticipantsFromES(@NonNull String realm, @NonNull String index) {
         Map<String, Map<String, Object>> esData = new HashMap<>();
         if (StringUtils.isNotBlank(index)) {
@@ -101,21 +178,7 @@ public class ElasticSearchUtil {
             try {
                 try (RestHighLevelClient client = getClientForElasticsearchCloud(TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.ES_URL),
                         TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.ES_USERNAME), TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.ES_PASSWORD))) {
-                    int scrollSize = 1000;
-                    SearchRequest searchRequest = new SearchRequest(index);
-                    SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-                    SearchResponse response = null;
-                    int i = 0;
-                    searchSourceBuilder.query(QueryBuilders.matchAllQuery()).sort(PROFILE_CREATED_AT, SortOrder.ASC);
-                    while (response == null || response.getHits().getHits().length != 0) {
-                        searchSourceBuilder.size(scrollSize);
-                        searchSourceBuilder.from(i * scrollSize);
-                        searchRequest.source(searchSourceBuilder);
-
-                        response = client.search(searchRequest, RequestOptions.DEFAULT);
-                        addingParticipantStructuredHits(response, esData, realm);
-                        i++;
-                    }
+                    esData = getDDPParticipantsFromES(realm, index, client);
                 }
             }
             catch (Exception e) {

--- a/src/test/java/org/broadinstitute/dsm/GBFTest.java
+++ b/src/test/java/org/broadinstitute/dsm/GBFTest.java
@@ -1,15 +1,30 @@
 package org.broadinstitute.dsm;
 
+import static org.broadinstitute.dsm.careevolve.Covid19OrderRegistrar.ADDRESS_FIELD;
+import static org.broadinstitute.dsm.careevolve.Covid19OrderRegistrar.FIRST_NAME_FIELD;
+import static org.broadinstitute.dsm.careevolve.Covid19OrderRegistrar.GUID_FIELD;
+import static org.broadinstitute.dsm.careevolve.Covid19OrderRegistrar.LAST_NAME_FIELD;
+import static org.broadinstitute.dsm.careevolve.Covid19OrderRegistrar.PROFILE_FIELD;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.ddp.db.TransactionWrapper;
+import org.broadinstitute.dsm.careevolve.Covid19OrderRegistrarTest;
 import org.broadinstitute.dsm.db.DDPInstance;
+import org.broadinstitute.dsm.exception.CareEvolveException;
 import org.broadinstitute.dsm.model.KitRequest;
+import org.broadinstitute.dsm.model.KitRequestSettings;
+import org.broadinstitute.dsm.model.ParticipantWrapper;
+import org.broadinstitute.dsm.model.ddp.DDPParticipant;
 import org.broadinstitute.dsm.model.gbf.*;
 import org.broadinstitute.dsm.statics.ApplicationConfigConstants;
 import org.broadinstitute.dsm.statics.DBConstants;
 import org.broadinstitute.dsm.util.DBUtil;
+import org.broadinstitute.dsm.util.EasyPostUtil;
+import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.SystemUtil;
 import org.broadinstitute.dsm.util.externalShipper.ExternalShipper;
 import org.broadinstitute.dsm.util.externalShipper.GBFRequestUtil;
@@ -21,10 +36,15 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class GBFTest extends TestHelper {
 
@@ -224,5 +244,62 @@ public class GBFTest extends TestHelper {
         else {
             Assert.fail("No apiKey found");
         }
+    }
+
+    @Test
+    public void orderGBFKit() throws Exception {
+        String externalOrderNumber = "T93CNUCZ8QHBSNRI1DJA";
+
+        String orderLookup = "select \n" +
+                "distinct req.ddp_participant_id\n" +
+                "FROM prod_dsm_db.ddp_kit_request req\n" +
+                "left join ddp_kit kit on\n" +
+                "(req.dsm_kit_request_id = kit.dsm_kit_request_id)\n" +
+                "where\n" +
+                "req.ddp_instance_id = 9\n" +
+                "and\n" +
+                "req.external_order_number = ?";
+
+        DDPInstance instance = DDPInstance.getDDPInstanceWithRole("testboston", DBConstants.HAS_KIT_REQUEST_ENDPOINTS);
+          ArrayList<KitRequest> kitsToOrder = new ArrayList<>();
+
+          EasyPostUtil easyPostUtil = new EasyPostUtil(null,"PwI372wBHmVyrdBqa2NoeA");
+        Map<String, Map<String, Object>> elasticMap = ElasticSearchUtil.getDDPParticipantsFromES(instance.getName(), instance.getParticipantIndexES());
+
+        HashMap<Integer, KitRequestSettings> kitRequestSettings = KitRequestSettings.getKitRequestSettings("9");
+
+        GBFRequestUtil shipper = new GBFRequestUtil();
+
+        TransactionWrapper.inTransaction(conn -> {
+            try {
+                try (PreparedStatement stmt = conn.prepareStatement(orderLookup)) {
+                    stmt.setString(1, externalOrderNumber);
+
+                    try (ResultSet rs = stmt.executeQuery()) {
+                        while (rs.next()) {
+                            String ddpParticipantId = rs.getString("ddp_participant_id");
+                            DDPParticipant participant = ElasticSearchUtil.getParticipantAsDDPParticipant(elasticMap, ddpParticipantId);
+
+                            kitsToOrder.add(new KitRequest(ddpParticipantId, participant.getShortId(), participant, externalOrderNumber));
+
+                            for (KitRequestSettings kitRequestSetting : kitRequestSettings.values()) {
+                                if ("gbf".equalsIgnoreCase(kitRequestSetting.getExternalShipper())) {
+                                    kitRequestSetting.setCarrierTo("3rd Day Air Residential");
+                                    kitRequestSetting.setServiceTo(kitRequestSetting.getCarrierTo());
+                                    System.out.println(kitRequestSetting.getCarrierTo());
+                                    shipper.orderKitRequests(kitsToOrder, easyPostUtil, kitRequestSetting, null);
+                                }
+                            }
+
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                logger.error("Could not order kit " + externalOrderNumber, e);
+            }
+
+            return null;
+        });
+
     }
 }


### PR DESCRIPTION
Something we should consider is offloading quartz jobs to cloud functions so that our API resources don't get dragged down by background jobs.  This is a POC that shows how a cloud function can be built and deployed with (hopefully) minimal impact on the current process for deploying the backend.  Early drafts used separate `pom.xml` files, but with creative use of [maven profiles](https://maven.apache.org/guides/introduction/introduction-to-profiles.html), we can use a single `pom.xml`.

[TestBostonKitTrackerDispatcher](https://github.com/broadinstitute/ddp-study-manager/pull/93/files#diff-8abf39e1f4eabae2c5323b9335964051e50098ae0831020915f9e4cd2244e548) does one thing: grabs a list of to/from UPS tracking numbers and prints them.

Because [cloud functions may cache and re-use `static` vars](https://cloud.google.com/functions/docs/bestpractices/tips#functions-tips-scopes-java) across invocations, I had to tease out a separate connection methodology.  There are probably more things like this that we will encounter as we move more things into cloud functions.

Cloud functions also have [hard limits](https://cloud.google.com/functions/quotas) in terms of memory and compute time, so `TestBostonKitTrackerDispatcher` is probably just one piece that creates a worklist, since generating 20,000 calls to UPS will probably take more than nine minutes.  Architecting our cloud functions to fit within these resource constraints will be a new and exciting endeavor!

Check out the [CF in GCP](https://console.cloud.google.com/functions/list?project=broad-ddp-dev&tab=logs).  You can kick the tires and view the logs.

@Irakli-Khaladze curious to get your feedback on this in the context of DDP-5445.

To build, be sure to use `-Pcould-function` in mvn, both command-line and Intellij.  Note that this change will also require use of `-Papis`for building backend APIs.