### PR TITLE
Changing functionality to send error notification to slack channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ config/test-gcloud-creds.json
 config/staging-gcloud-creds.json
 config/prod-gcloud-creds.json
 
+vault.conf
+liquibase.properties
+
 src/test/resources/output
 target/
 app-deploy
@@ -66,3 +69,4 @@ logs
 *.pem
 *.env
 *.jks
+

--- a/.gitignore
+++ b/.gitignore
@@ -55,13 +55,9 @@ config/test-gcloud-creds.json
 config/staging-gcloud-creds.json
 config/prod-gcloud-creds.json
 
-vault.conf
-liquibase.properties
-
 src/test/resources/output
 target/
 app-deploy
-
 
 logs
 *.log

--- a/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.broadinstitute.ddp.BasicServer;
+import org.broadinstitute.ddp.loggers.ErrorNotificationAppender;
 import org.broadinstitute.ddp.security.Auth0Util;
 import org.broadinstitute.ddp.security.CookieUtil;
 import org.broadinstitute.ddp.util.BasicTriggerListener;
@@ -32,6 +33,7 @@ import org.broadinstitute.dsm.careevolve.Authentication;
 import org.broadinstitute.dsm.careevolve.Provider;
 import org.broadinstitute.dsm.jetty.JettyConfig;
 import org.broadinstitute.dsm.jobs.*;
+import org.broadinstitute.dsm.log.SlackAppender;
 import org.broadinstitute.dsm.model.mbc.MBCHospital;
 import org.broadinstitute.dsm.model.mbc.MBCInstitution;
 import org.broadinstitute.dsm.model.mbc.MBCParticipant;
@@ -623,6 +625,23 @@ public class DSMServer extends BasicServer {
             }
         }
         setupErrorNotifications(cfg, schedulerName);
+    }
+
+
+    @Override
+    protected void setupErrorNotifications(Config config, String schedulerName) {
+        if (config == null) {
+            throw new NullPointerException("config");
+        } else {
+            logger.info("Setup error notifications...");
+            if (config.hasPath("slack.hook") && config.hasPath("slack.channel")) {
+                SlackAppender.configure(config, schedulerName);
+                logger.info("Error notification setup complete. If log4j.xml is configured, notifications will be sent to " + config.getString("slack.channel") + ".");
+            } else {
+                logger.warn("Skipping error notification setup.");
+            }
+
+        }
     }
 
     /**

--- a/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -659,7 +659,7 @@ public class DSMServer extends BasicServer {
                 try {
                     slackHookUrl = new URI(slackHookUrlString);
                 } catch (URISyntaxException e) {
-                    throw new IllegalArgumentException("Could not parse " + slackHookUrlString);
+                    throw new IllegalArgumentException("Could not parse " + slackHookUrlString + "\n" + e);
                 }
                 SlackAppender.configure(schedulerName, appEnv, slackHookUrl, slackChannel);
                 logger.info("Error notification setup complete. If log4j.xml is configured, notifications will be sent to " + slackChannel + ".");

--- a/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -662,7 +662,7 @@ public class DSMServer extends BasicServer {
                     throw new IllegalArgumentException("Could not parse " + slackHookUrlString);
                 }
                 SlackAppender.configure(schedulerName, appEnv, slackHookUrl, slackChannel);
-                logger.info("Error notification setup complete. If log4j.xml is configured, notifications will be sent to " + config.getString("slack.channel") + ".");
+                logger.info("Error notification setup complete. If log4j.xml is configured, notifications will be sent to " + slackChannel + ".");
             } else {
                 logger.warn("Skipping error notification setup.");
             }

--- a/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
+++ b/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
@@ -1,8 +1,11 @@
 package org.broadinstitute.dsm.log;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicLong;
@@ -21,7 +24,7 @@ import org.broadinstitute.ddp.util.Utility;
 public class SlackAppender extends AppenderSkeleton {
 
     public static final String APPENDER_NAME = "slackAppender";
-    private static SendGridClient emailClient;
+    private static HttpClient httpClient;
     private static String appEnv;
     private static String schedulerName;
     private static URI slackHookUrl;
@@ -31,27 +34,21 @@ public class SlackAppender extends AppenderSkeleton {
     private static AtomicLong minEpochForNextError = new AtomicLong(0L);
     private static final int JOB_DELAY = 60;
     private static final int NON_JOB_DELAY = 30;
-    private static final String ERROR_MESSAGE = "<p>An error has been detected for <b>%s</b>. Please go check the backend logs around <b>%s UTC</b>.</p><p>%s</p><p>%s</p>";
-    private static final String JOB_THROTTLE_NOTE = "This looks like a job error. Job error reporting is throttled so you will only see 1 per %s minutes.";
-    private static final String NON_JOB_THROTTLE_NOTE = "This does NOT look like a job error. Non-job error reporting is throttled so you will only see 1 per %s minutes.";
     private static final String MSG_TYPE_JOB_ERROR = "JOB_ERROR_ALERT";
     private static final String MSG_TYPE_ERROR = "ERROR_ALERT";
 
     @Override
     protected void append(LoggingEvent event) {
         if (configured && event.getLevel().toInt() == 40000) {
-            SlackMessagePayload payload = null;
             try {
                 boolean jobError = schedulerName != null && event.getThreadName().contains(schedulerName);
                 long currentEpoch = Utility.getCurrentEpoch();
                 if (jobError && currentEpoch >= minEpochForNextJobError.get()) {
-                    payload = new SlackMessagePayload(String.format("This looks like a job error. Job error reporting is " +
-                            "throttled so you will only see 1 per %s minutes.", 60), slackChannel, "DSM", ":nerd_face:");
                     this.sendSlackNotification(currentEpoch, String.format("This looks like a job error. Job error reporting is " +
-                            "throttled so you will only see 1 per %s minutes.", 60), "JOB_ERROR_ALERT", payload);
+                            "throttled so you will only see 1 per %s minutes.", JOB_DELAY), MSG_TYPE_JOB_ERROR);
                     minEpochForNextJobError.set(currentEpoch + 3600L);
                 } else if (!jobError && currentEpoch >= minEpochForNextError.get()) {
-                    this.sendSlackNotification(currentEpoch, String.format("This does NOT look like a job error. Non-job error reporting is throttled so you will only see 1 per %s minutes.", 30), "ERROR_ALERT", );
+                    this.sendSlackNotification(currentEpoch, String.format("This does NOT look like a job error. Non-job error reporting is throttled so you will only see 1 per %s minutes.", NON_JOB_DELAY), MSG_TYPE_ERROR);
                     minEpochForNextError.set(currentEpoch + 1800L);
                 }
             } catch (Exception var5) {
@@ -60,14 +57,26 @@ public class SlackAppender extends AppenderSkeleton {
         }
     }
 
-    private void sendSlackNotification(long currentEpoch, String note, String messageType, SlackMessagePayload payload) {
+    private void sendSlackNotification(long currentEpoch, String note, String messageType) {
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         String date = formatter.format(new Date(currentEpoch * 1000L));
+        SlackMessagePayload payload = new SlackMessagePayload(String.format("An error has been detected for *%s*. Please go check the backend logs around *%s UTC*. \n" +
+                "%s \n %s", appEnv, date, messageType, note), slackChannel, "DSM", ":nerd_face:");
         HttpRequest httpRequest = HttpRequest.newBuilder()
                 .uri(slackHookUrl)
                 .POST(HttpRequest.BodyPublishers.ofString(new Gson().toJson(payload)))
                 .header(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
                 .build();
+
+        try {
+            HttpResponse<String> response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                throw new IOException("Could not post " + payload + " to slack.  Hook returned " + response.body());
+            }
+        } catch (IOException | InterruptedException e) {
+            System.out.println("Could not post error message to slack room " + slackChannel + " with hook " + slackHookUrl
+                    + "\n" + ExceptionUtils.getStackTrace(e));
+        }
     }
 
     @Override
@@ -91,6 +100,7 @@ public class SlackAppender extends AppenderSkeleton {
             } catch (URISyntaxException e) {
                 throw new IllegalArgumentException("Could not parse " + slackHookUrl);
             }
+            httpClient = HttpClient.newHttpClient();
             slackChannel = config.getString("slack.channel");
             schedulerName = scheduler;
             configured = true;

--- a/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
+++ b/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
@@ -1,9 +1,88 @@
 package org.broadinstitute.dsm.log;
 
-import org.broadinstitute.ddp.loggers.ErrorNotificationAppender;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicLong;
 
-public class SlackAppender extends ErrorNotificationAppender {
-    public SlackAppender() {
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.typesafe.config.Config;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.spi.LoggingEvent;
+import org.broadinstitute.ddp.email.SendGridClient;
+import org.broadinstitute.ddp.util.EDCClient;
+import org.broadinstitute.ddp.util.Utility;
+
+public class SlackAppender extends AppenderSkeleton {
+
+    public static final String APPENDER_NAME = "slackAppender";
+    private static SendGridClient emailClient;
+    private static String appEnv;
+    private static String schedulerName;
+    private static String slackHook;
+    private static String slackChannel;
+    private static boolean configured = false;
+    private static AtomicLong minEpochForNextJobError = new AtomicLong(0L);
+    private static AtomicLong minEpochForNextError = new AtomicLong(0L);
+    private static final int JOB_DELAY = 60;
+    private static final int NON_JOB_DELAY = 30;
+    private static final String ERROR_MESSAGE = "<p>An error has been detected for <b>%s</b>. Please go check the backend logs around <b>%s UTC</b>.</p><p>%s</p><p>%s</p>";
+    private static final String JOB_THROTTLE_NOTE = "This looks like a job error. Job error reporting is throttled so you will only see 1 per %s minutes.";
+    private static final String NON_JOB_THROTTLE_NOTE = "This does NOT look like a job error. Non-job error reporting is throttled so you will only see 1 per %s minutes.";
+    private static final String MSG_TYPE_JOB_ERROR = "JOB_ERROR_ALERT";
+    private static final String MSG_TYPE_ERROR = "ERROR_ALERT";
+
+    @Override
+    protected void append(LoggingEvent event) {
+        if (configured && event.getLevel().toInt() == 40000) {
+            try {
+                boolean jobError = schedulerName != null && event.getThreadName().contains(schedulerName);
+                long currentEpoch = Utility.getCurrentEpoch();
+                if (jobError && currentEpoch >= minEpochForNextJobError.get()) {
+                    this.sendSlackNotification(currentEpoch, String.format("This looks like a job error. Job error reporting is throttled so you will only see 1 per %s minutes.", 60), "JOB_ERROR_ALERT");
+                    minEpochForNextJobError.set(currentEpoch + 3600L);
+                } else if (!jobError && currentEpoch >= minEpochForNextError.get()) {
+                    this.sendSlackNotification(currentEpoch, String.format("This does NOT look like a job error. Non-job error reporting is throttled so you will only see 1 per %s minutes.", 30), "ERROR_ALERT");
+                    minEpochForNextError.set(currentEpoch + 1800L);
+                }
+            } catch (Exception var5) {
+                System.out.println("ErrorNotificationAppender Error: " + ExceptionUtils.getStackTrace(var5));
+            }
+        }
     }
 
+    private void sendSlackNotification(long currentEpoch, String note, String messageType) {
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        String date = formatter.format(new Date(currentEpoch * 1000L));
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public boolean requiresLayout() {
+        return false;
+    }
+
+
+    public static synchronized void configure(Config config, String scheduler) {
+        if (config == null) {
+            throw new NullPointerException("config");
+        } else if (!configured) {
+            appEnv = config.getString("portal.environment");
+            slackHook = config.getString("slack.hook");
+            slackChannel = config.getString("slack.channel");
+            emailClient = new SendGridClient();
+            JsonObject settings = (JsonObject)((JsonObject)(new JsonParser()).parse(config.getString("errorAlert.clientSettings")));
+            emailClient.configure(config.getString("errorAlert.key"), settings, "", (EDCClient)null, appEnv);
+            schedulerName = scheduler;
+            configured = true;
+        } else {
+            throw new RuntimeException("Configure has already been called for this appender.");
+        }
+    }
 }

--- a/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
+++ b/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
@@ -1,17 +1,21 @@
 package org.broadinstitute.dsm.log;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpRequest;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicLong;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
 import com.typesafe.config.Config;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.http.HttpHeaders;
+import org.apache.http.entity.ContentType;
 import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.spi.LoggingEvent;
 import org.broadinstitute.ddp.email.SendGridClient;
-import org.broadinstitute.ddp.util.EDCClient;
 import org.broadinstitute.ddp.util.Utility;
 
 public class SlackAppender extends AppenderSkeleton {
@@ -20,7 +24,7 @@ public class SlackAppender extends AppenderSkeleton {
     private static SendGridClient emailClient;
     private static String appEnv;
     private static String schedulerName;
-    private static String slackHook;
+    private static URI slackHookUrl;
     private static String slackChannel;
     private static boolean configured = false;
     private static AtomicLong minEpochForNextJobError = new AtomicLong(0L);
@@ -36,14 +40,18 @@ public class SlackAppender extends AppenderSkeleton {
     @Override
     protected void append(LoggingEvent event) {
         if (configured && event.getLevel().toInt() == 40000) {
+            SlackMessagePayload payload = null;
             try {
                 boolean jobError = schedulerName != null && event.getThreadName().contains(schedulerName);
                 long currentEpoch = Utility.getCurrentEpoch();
                 if (jobError && currentEpoch >= minEpochForNextJobError.get()) {
-                    this.sendSlackNotification(currentEpoch, String.format("This looks like a job error. Job error reporting is throttled so you will only see 1 per %s minutes.", 60), "JOB_ERROR_ALERT");
+                    payload = new SlackMessagePayload(String.format("This looks like a job error. Job error reporting is " +
+                            "throttled so you will only see 1 per %s minutes.", 60), slackChannel, "DSM", ":nerd_face:");
+                    this.sendSlackNotification(currentEpoch, String.format("This looks like a job error. Job error reporting is " +
+                            "throttled so you will only see 1 per %s minutes.", 60), "JOB_ERROR_ALERT", payload);
                     minEpochForNextJobError.set(currentEpoch + 3600L);
                 } else if (!jobError && currentEpoch >= minEpochForNextError.get()) {
-                    this.sendSlackNotification(currentEpoch, String.format("This does NOT look like a job error. Non-job error reporting is throttled so you will only see 1 per %s minutes.", 30), "ERROR_ALERT");
+                    this.sendSlackNotification(currentEpoch, String.format("This does NOT look like a job error. Non-job error reporting is throttled so you will only see 1 per %s minutes.", 30), "ERROR_ALERT", );
                     minEpochForNextError.set(currentEpoch + 1800L);
                 }
             } catch (Exception var5) {
@@ -52,10 +60,14 @@ public class SlackAppender extends AppenderSkeleton {
         }
     }
 
-    private void sendSlackNotification(long currentEpoch, String note, String messageType) {
+    private void sendSlackNotification(long currentEpoch, String note, String messageType, SlackMessagePayload payload) {
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         String date = formatter.format(new Date(currentEpoch * 1000L));
-
+        HttpRequest httpRequest = HttpRequest.newBuilder()
+                .uri(slackHookUrl)
+                .POST(HttpRequest.BodyPublishers.ofString(new Gson().toJson(payload)))
+                .header(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
+                .build();
     }
 
     @Override
@@ -74,15 +86,41 @@ public class SlackAppender extends AppenderSkeleton {
             throw new NullPointerException("config");
         } else if (!configured) {
             appEnv = config.getString("portal.environment");
-            slackHook = config.getString("slack.hook");
+            try {
+                slackHookUrl = new URI(config.getString("slack.hook"));
+            } catch (URISyntaxException e) {
+                throw new IllegalArgumentException("Could not parse " + slackHookUrl);
+            }
             slackChannel = config.getString("slack.channel");
-            emailClient = new SendGridClient();
-            JsonObject settings = (JsonObject)((JsonObject)(new JsonParser()).parse(config.getString("errorAlert.clientSettings")));
-            emailClient.configure(config.getString("errorAlert.key"), settings, "", (EDCClient)null, appEnv);
             schedulerName = scheduler;
             configured = true;
         } else {
             throw new RuntimeException("Configure has already been called for this appender.");
+        }
+    }
+
+    static class SlackMessagePayload {
+
+        @SerializedName("text")
+        private String text;
+
+        @SerializedName("channel")
+        private String channel;
+
+        @SerializedName("username")
+        private String username;
+
+        @SerializedName("icon_emoji")
+        private String iconEmoji;
+
+        @SerializedName("unfurl_links")
+        private boolean unfurlLinks = false;
+
+        public SlackMessagePayload(String text, String channel, String username, String iconEmoji) {
+            this.text = text;
+            this.channel = channel;
+            this.username = username;
+            this.iconEmoji = iconEmoji;
         }
     }
 }

--- a/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
+++ b/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
@@ -12,7 +12,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
-import com.typesafe.config.Config;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.entity.ContentType;
@@ -96,18 +95,12 @@ public class SlackAppender extends AppenderSkeleton {
     }
 
 
-    public static synchronized void configure(Config config, String scheduler) {
-        if (config == null) {
-            throw new NullPointerException("config");
-        } else if (!configured) {
-            appEnv = config.getString("portal.environment");
-            try {
-                slackHookUrl = new URI(config.getString("slack.hook"));
-            } catch (URISyntaxException e) {
-                throw new IllegalArgumentException("Could not parse " + slackHookUrl);
-            }
+    public static synchronized void configure(String scheduler, String appEnv, URI slackHookUri, String slackChannel) {
+        if (!configured) {
+            SlackAppender.appEnv = appEnv;
+            slackHookUrl = slackHookUri;
             httpClient = HttpClient.newHttpClient();
-            slackChannel = config.getString("slack.channel");
+            SlackAppender.slackChannel = slackChannel;
             schedulerName = scheduler;
             configured = true;
         } else {

--- a/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
+++ b/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
@@ -59,10 +59,7 @@ public class SlackAppender extends AppenderSkeleton {
     }
 
     private void sendSlackNotification(long currentEpoch, String note, String messageType) {
-        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        String date = formatter.format(new Date(currentEpoch * 1000L));
-        SlackMessagePayload payload = new SlackMessagePayload(String.format("An error has been detected for *%s*. Please go check the backend logs around *%s UTC*. \n" +
-                "%s \n %s", appEnv, date, messageType, note), slackChannel, "DSM", ":nerd_face:");
+        SlackMessagePayload payload = getSlackMessagePayload(currentEpoch, note, messageType);
         HttpRequest httpRequest = HttpRequest.newBuilder()
                 .uri(slackHookUrl)
                 .POST(HttpRequest.BodyPublishers.ofString(new Gson().toJson(payload)))
@@ -78,6 +75,14 @@ public class SlackAppender extends AppenderSkeleton {
             System.out.println("Could not post error message to slack room " + slackChannel + " with hook " + slackHookUrl
                     + "\n" + ExceptionUtils.getStackTrace(e));
         }
+    }
+
+    public SlackMessagePayload getSlackMessagePayload(long currentEpoch, String note, String messageType) {
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        String date = formatter.format(new Date(currentEpoch * 1000L));
+        SlackMessagePayload payload = new SlackMessagePayload(String.format("An error has been detected for *%s*. Please go check the backend logs around *%s UTC*. \n" +
+                "%s \n %s", appEnv, date, messageType, note), slackChannel, "DSM", ":nerd_face:");
+        return payload;
     }
 
     @Override

--- a/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
+++ b/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
@@ -51,11 +51,11 @@ public class SlackAppender extends AppenderSkeleton {
                 if (jobError && currentEpoch >= minEpochForNextJobError.get()) {
                     this.sendSlackNotification(currentEpoch, String.format("This looks like a job error. Job error reporting is " +
                             "throttled so you will only see 1 per %s minutes.", JOB_DELAY), MSG_TYPE_JOB_ERROR);
-                    minEpochForNextJobError.set(currentEpoch + 3600L);
+                    minEpochForNextJobError.set(currentEpoch + JOB_DELAY * 60L);
                 } else if (!jobError && currentEpoch >= minEpochForNextError.get()) {
                     this.sendSlackNotification(currentEpoch, String.format("This does NOT look like a job error. " +
                             "Non-job error reporting is throttled so you will only see 1 per %s minutes.", NON_JOB_DELAY), MSG_TYPE_ERROR);
-                    minEpochForNextError.set(currentEpoch + 1800L);
+                    minEpochForNextError.set(currentEpoch + NON_JOB_DELAY * 60L);
                 }
             } catch (Exception var5) {
                 logger.warn("ErrorNotificationAppender Error: " + ExceptionUtils.getStackTrace(var5));

--- a/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
+++ b/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
@@ -18,7 +18,6 @@ import org.apache.http.HttpHeaders;
 import org.apache.http.entity.ContentType;
 import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.spi.LoggingEvent;
-import org.broadinstitute.ddp.email.SendGridClient;
 import org.broadinstitute.ddp.util.Utility;
 
 public class SlackAppender extends AppenderSkeleton {

--- a/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
+++ b/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
@@ -1,0 +1,9 @@
+package org.broadinstitute.dsm.log;
+
+import org.broadinstitute.ddp.loggers.ErrorNotificationAppender;
+
+public class SlackAppender extends ErrorNotificationAppender {
+    public SlackAppender() {
+    }
+
+}

--- a/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
+++ b/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
@@ -89,7 +89,7 @@ public class SlackAppender extends AppenderSkeleton {
         String date = formatter.format(new Date(currentEpoch * 1000L));
         SlackMessagePayload payload = new SlackMessagePayload(String.format("An error has been detected for *%s*." +
                 " Please go check the backend logs around *%s UTC*. \n" + "%s \n %s",
-                appEnv, date, messageType, note), slackChannel, "DSM", ":nerd_face:");
+                appEnv, date, messageType, note), slackChannel, "Study-Manager", ":nerd_face:");
         return payload;
     }
 

--- a/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
+++ b/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
@@ -22,6 +22,8 @@ import org.broadinstitute.ddp.email.SendGridClient;
 import org.broadinstitute.ddp.util.Utility;
 
 public class SlackAppender extends AppenderSkeleton {
+    public SlackAppender() {
+    }
 
     public static final String APPENDER_NAME = "slackAppender";
     private static HttpClient httpClient;

--- a/src/main/resources/log4j.xml
+++ b/src/main/resources/log4j.xml
@@ -14,7 +14,7 @@
             <param name="ConversionPattern" value="%d{ISO8601} %-5p %X{CLIENT_IP} [%t] (%C.%M:%L) - %m%n"/>
         </layout>
     </appender>
-    <appender name="errorNotification" class="org.broadinstitute.ddp.loggers.ErrorNotificationAppender">
+    <appender name="errorNotification" class="org.broadinstitute.dsm.log.SlackAppender">
     </appender>
     <root>
         <priority value ="info" />

--- a/src/test/java/org/broadinstitute/dsm/log/SlackAppenderTest.java
+++ b/src/test/java/org/broadinstitute/dsm/log/SlackAppenderTest.java
@@ -1,17 +1,12 @@
 package org.broadinstitute.dsm.log;
 
-import static org.junit.Assert.*;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
-
-import java.text.SimpleDateFormat;
-import java.util.Date;
 
 import com.google.gson.Gson;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValueFactory;
 import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
 import org.apache.log4j.spi.RootLogger;
 import org.broadinstitute.ddp.util.Utility;
@@ -56,7 +51,7 @@ public class SlackAppenderTest extends TestHelper {
             cfg = cfg.withValue("slack.hook", ConfigValueFactory.fromAnyRef("http://localhost:" + mockDDP.getPort() + "/mock_slack_test"));
             cfg = cfg.withValue("slack.channel", ConfigValueFactory.fromAnyRef("SlackChannel"));
 
-            SlackAppender.configure(cfg, null);
+            SlackAppender.configure(null, , , );
 
             slackAppender.doAppend(loggingEvent);
 

--- a/src/test/java/org/broadinstitute/dsm/log/SlackAppenderTest.java
+++ b/src/test/java/org/broadinstitute/dsm/log/SlackAppenderTest.java
@@ -3,6 +3,9 @@ package org.broadinstitute.dsm.log;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import com.google.gson.Gson;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValueFactory;
@@ -51,7 +54,17 @@ public class SlackAppenderTest extends TestHelper {
             cfg = cfg.withValue("slack.hook", ConfigValueFactory.fromAnyRef("http://localhost:" + mockDDP.getPort() + "/mock_slack_test"));
             cfg = cfg.withValue("slack.channel", ConfigValueFactory.fromAnyRef("SlackChannel"));
 
-            SlackAppender.configure(null, , , );
+            String appEnv = cfg.getString("portal.environment");
+            String slackHookUrlString = cfg.getString("slack.hook");
+            URI slackHookUrl;
+            String slackChannel = cfg.getString("slack.channel");
+            try {
+                slackHookUrl = new URI(slackHookUrlString);
+            } catch (URISyntaxException e) {
+                throw new IllegalArgumentException("Could not parse " + slackHookUrlString);
+            }
+
+            SlackAppender.configure(null, appEnv, slackHookUrl, slackChannel);
 
             slackAppender.doAppend(loggingEvent);
 

--- a/src/test/java/org/broadinstitute/dsm/log/SlackAppenderTest.java
+++ b/src/test/java/org/broadinstitute/dsm/log/SlackAppenderTest.java
@@ -5,7 +5,10 @@ import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
 import com.google.gson.Gson;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
+import org.apache.log4j.spi.RootLogger;
 import org.broadinstitute.dsm.TestHelper;
 import org.junit.Assert;
 import org.junit.Before;
@@ -20,12 +23,12 @@ public class SlackAppenderTest extends TestHelper {
     @Rule
     public MockServerRule mockServerRule = new MockServerRule(this);
 
-
-    private LoggingEvent loggingEvent = new LoggingEvent(null, null, null, null, null);
+    private LoggingEvent loggingEvent = new LoggingEvent(null, new RootLogger(Level.ERROR), Level.ERROR, null, null);
 
     @Before
     public void setUp() {
         loggingEvent.setProperty("Hi", "There");
+        setupDB();
     }
 
     @Test
@@ -41,12 +44,11 @@ public class SlackAppenderTest extends TestHelper {
 
             SlackAppender slackAppender = new SlackAppender();
 
-            slackAppender.;
+            SlackAppender.configure(TestHelper.cfg, null);
+
             slackAppender.doAppend(loggingEvent);
 
-            slackAppender.waitForClearToQueue(3000);
-
-            mockServerClient.verify(request().withPath("/mock_slack_test").withBody(JsonBody.json(
+            mockDDP.verify(request().withPath("/mock_slack_test").withBody(JsonBody.json(
                     new Gson().toJson(new SlackAppender.SlackMessagePayload("*Hi there*\n ``````",
                             "SlackChannel",
                             "Pepper",

--- a/src/test/java/org/broadinstitute/dsm/log/SlackAppenderTest.java
+++ b/src/test/java/org/broadinstitute/dsm/log/SlackAppenderTest.java
@@ -1,0 +1,59 @@
+package org.broadinstitute.dsm.log;
+
+import static org.junit.Assert.*;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+import com.google.gson.Gson;
+import org.apache.log4j.spi.LoggingEvent;
+import org.broadinstitute.dsm.TestHelper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockserver.junit.MockServerRule;
+import org.mockserver.model.JsonBody;
+
+public class SlackAppenderTest extends TestHelper {
+
+
+    @Rule
+    public MockServerRule mockServerRule = new MockServerRule(this);
+
+
+    private LoggingEvent loggingEvent = new LoggingEvent(null, null, null, null, null);
+
+    @Before
+    public void setUp() {
+        loggingEvent.setProperty("Hi", "There");
+    }
+
+    @Test
+    public void testSuccessfulLoggingToSlack() throws Exception {
+
+        TestHelper.startMockServer();
+
+        if (mockDDP.isRunning()) {
+            mockDDP.when(request().withPath("/mock_slack_test"))
+                    .respond(response()
+                            .withStatusCode(200)
+                            .withBody("ok"));
+
+            SlackAppender slackAppender = new SlackAppender();
+
+            slackAppender.;
+            slackAppender.doAppend(loggingEvent);
+
+            slackAppender.waitForClearToQueue(3000);
+
+            mockServerClient.verify(request().withPath("/mock_slack_test").withBody(JsonBody.json(
+                    new Gson().toJson(new SlackAppender.SlackMessagePayload("*Hi there*\n ``````",
+                            "SlackChannel",
+                            "Pepper",
+                            ":nerd_face:")))));
+        } else {
+            Assert.fail("Mock slack not running");
+        }
+    }
+
+}


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/browse/DDP-5446

Used the same approach like it was before for sending error notification to email.

Added class SlackAppender:

- append method which handles to categorize errors
- sendSlackNotification method which handles to send passed error message to slack
- getSlackMessagePayload factory method which creates message payload as java object
- configure method used in DSMServer.setupErrorNotification to configure SlackAppender  with slack credentials from config file

To make functionality work we need to add slack configurations in main .conf file:
`"slack": 
{
        "hook": "<slack-hook-url>", 
        "channel": "<slack-channel-name>"
    }
`

