### PR TITLE
DDP-5556: Duplicate initial biopsy

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/db/MedicalRecord.java
+++ b/src/main/java/org/broadinstitute/dsm/db/MedicalRecord.java
@@ -40,7 +40,7 @@ public class MedicalRecord {
             "LEFT JOIN ddp_medical_record_log log on (rec2.medical_record_id = log.medical_record_id) WHERE rec2.institution_id = inst.institution_id) as reviewMedicalRecord " +
             "FROM ddp_institution inst LEFT JOIN ddp_participant as p on (p.participant_id = inst.participant_id) " +
             "LEFT JOIN ddp_instance as ddp on (ddp.ddp_instance_id = p.ddp_instance_id) LEFT JOIN ddp_medical_record as m on (m.institution_id = inst.institution_id) " +
-            "WHERE ddp.instance_name = ? AND inst.type != 'NOT_SPECIFIED' ";
+            "WHERE ddp.instance_name = ? AND inst.type != 'NOT_SPECIFIED' AND NOT m.deleted <=> 1 ";
     public static final String SQL_SELECT_MEDICAL_RECORD_LAST_CHANGED = "SELECT m.last_changed FROM ddp_institution inst " +
             "LEFT JOIN ddp_participant as p on (p.participant_id = inst.participant_id) LEFT JOIN ddp_instance as ddp on (ddp.ddp_instance_id = p.ddp_instance_id) " +
             "LEFT JOIN ddp_medical_record as m on (m.institution_id = inst.institution_id) WHERE p.participant_id = ?";

--- a/src/main/java/org/broadinstitute/dsm/db/OncHistoryDetail.java
+++ b/src/main/java/org/broadinstitute/dsm/db/OncHistoryDetail.java
@@ -39,7 +39,7 @@ public class OncHistoryDetail {
             "sent_gp, first_sm_id, additional_tissue_value_json, expected_return, return_date, return_fedex_id, shl_work_number, tumor_percentage, tissue_sequence, " +
             " scrolls_count, uss_count, h_e_count, blocks_count " +
             "FROM ddp_onc_history_detail oD " +
-            "LEFT JOIN ddp_medical_record m on (oD.medical_record_id = m.medical_record_id AND NOT oD.deleted <=> 1) " +
+            "LEFT JOIN ddp_medical_record m on (oD.medical_record_id = m.medical_record_id AND NOT oD.deleted <=> 1 AND NOT m.deleted <=> 1) " +
             "LEFT JOIN ddp_institution inst on (inst.institution_id = m.institution_id) " +
             "LEFT JOIN ddp_participant p on (p.participant_id = inst.participant_id) " +
             "LEFT JOIN ddp_instance realm on (p.ddp_instance_id = realm.ddp_instance_id) " +
@@ -54,7 +54,7 @@ public class OncHistoryDetail {
     public static final String SQL_ORDER_BY = " ORDER BY p.ddp_participant_id, inst.ddp_institution_id, oD.onc_history_detail_id ASC";
     public static final String SQL_SELECT_ONC_HISTORY_LAST_CHANGED = "SELECT oD.last_changed FROM ddp_institution inst " +
             "LEFT JOIN ddp_participant as p on (p.participant_id = inst.participant_id) LEFT JOIN ddp_instance as ddp on (ddp.ddp_instance_id = p.ddp_instance_id) " +
-            "LEFT JOIN ddp_medical_record as m on (m.institution_id = inst.institution_id) LEFT JOIN ddp_onc_history_detail as oD on (m.medical_record_id = oD.medical_record_id) " +
+            "LEFT JOIN ddp_medical_record as m on (m.institution_id = inst.institution_id AND NOT m.deleted <=> 1) LEFT JOIN ddp_onc_history_detail as oD on (m.medical_record_id = oD.medical_record_id) " +
             "WHERE p.participant_id = ?";
 
     public static final String STATUS_REVIEW = "review";

--- a/src/main/java/org/broadinstitute/dsm/db/ParticipantStatus.java
+++ b/src/main/java/org/broadinstitute/dsm/db/ParticipantStatus.java
@@ -20,7 +20,7 @@ public class ParticipantStatus {
             "UNIX_TIMESTAMP(str_to_date(min(tis.sent_gp), '%Y-%m-%d')) as tissueSent FROM ddp_medical_record med " +
             "LEFT JOIN ddp_institution inst on (med.institution_id = inst.institution_id) LEFT JOIN ddp_participant as part on (part.participant_id = inst.participant_id) " +
             "LEFT JOIN ddp_onc_history_detail onc on (med.medical_record_id = onc.medical_record_id) LEFT JOIN ddp_tissue tis on (tis.onc_history_detail_id = onc.onc_history_detail_id) " +
-            "WHERE part.ddp_participant_id = ? AND part.ddp_instance_id = ? GROUP BY ddp_participant_id";
+            "WHERE part.ddp_participant_id = ? AND part.ddp_instance_id = ? AND NOT med.deleted <=> 1 GROUP BY ddp_participant_id";
 
     private Long mrRequested;
     private Long mrReceived;

--- a/src/main/java/org/broadinstitute/dsm/db/Tissue.java
+++ b/src/main/java/org/broadinstitute/dsm/db/Tissue.java
@@ -32,7 +32,7 @@ public class Tissue {
     private static final String SQL_INSERT_TISSUE = "INSERT INTO ddp_tissue SET onc_history_detail_id = ?, last_changed = ?, changed_by = ?";
     public static final String SQL_SELECT_TISSUE_LAST_CHANGED = "SELECT t.last_changed FROM ddp_institution inst " +
             "LEFT JOIN ddp_participant as p on (p.participant_id = inst.participant_id) LEFT JOIN ddp_instance as ddp on (ddp.ddp_instance_id = p.ddp_instance_id) " +
-            "LEFT JOIN ddp_medical_record as m on (m.institution_id = inst.institution_id) LEFT JOIN ddp_onc_history_detail as oD on (m.medical_record_id = oD.medical_record_id) " +
+            "LEFT JOIN ddp_medical_record as m on (m.institution_id = inst.institution_id AND NOT m.deleted <=> 1) LEFT JOIN ddp_onc_history_detail as oD on (m.medical_record_id = oD.medical_record_id) " +
             "LEFT JOIN ddp_tissue as t on (t.onc_history_detail_id = oD.onc_history_detail_id) WHERE p.participant_id = ?";
 
     private String tissueId;

--- a/src/main/java/org/broadinstitute/dsm/model/TissueList.java
+++ b/src/main/java/org/broadinstitute/dsm/model/TissueList.java
@@ -29,7 +29,7 @@ public class TissueList {
             "t.scrolls_count, t.h_e_count, t.uss_count, t.blocks_count " +
             "FROM ddp_participant p LEFT JOIN ddp_instance realm on (p.ddp_instance_id = realm.ddp_instance_id) " +
             "LEFT JOIN ddp_participant_exit ex on (p.ddp_participant_id = ex.ddp_participant_id AND p.ddp_instance_id = ex.ddp_instance_id) " +
-            "LEFT JOIN ddp_institution inst on (p.participant_id = inst.participant_id) LEFT JOIN ddp_medical_record m on (m.institution_id = inst.institution_id) " +
+            "LEFT JOIN ddp_institution inst on (p.participant_id = inst.participant_id) LEFT JOIN ddp_medical_record m on (m.institution_id = inst.institution_id AND NOT m.deleted <=> 1) " +
             "LEFT JOIN ddp_onc_history_detail oD on (m.medical_record_id = oD.medical_record_id AND NOT oD.deleted <=> 1) " +
             "LEFT JOIN ddp_tissue t on (oD.onc_history_detail_id = t.onc_history_detail_id AND NOT t.deleted <=> 1) WHERE realm.instance_name = ? AND ex.ddp_participant_exit_id IS NULL AND oD.onc_history_detail_id IS NOT NULL";
     public static final String SQL_ORDER_BY_ONC_HISTORY = " ORDER BY oD.onc_history_detail_id ";

--- a/src/main/java/org/broadinstitute/dsm/route/LookupRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/LookupRoute.java
@@ -31,7 +31,7 @@ public class LookupRoute extends RequestHandler {
     private static final String SQL_SELECT_TISSUE_SITE = "SELECT DISTINCT tissue_site FROM ddp_tissue WHERE tissue_site LIKE ?";
     private static final String SQL_SELECT_TYPE = "SELECT DISTINCT type_px " +
             "FROM ddp_onc_history_detail oD " +
-            "LEFT JOIN ddp_medical_record m on (m.medical_record_id = oD.medical_record_id) " +
+            "LEFT JOIN ddp_medical_record m on (m.medical_record_id = oD.medical_record_id AND NOT m.deleted <=> 1) " +
             "LEFT JOIN ddp_institution inst on (m.institution_id = inst.institution_id) " +
             "LEFT JOIN  ddp_participant p on (p.participant_id = inst.participant_id) " +
             "LEFT JOIN ddp_instance realm on (p.ddp_instance_id = realm.ddp_instance_id) " +
@@ -41,7 +41,7 @@ public class LookupRoute extends RequestHandler {
     private static final String SQL_SELECT_FACILITY = "SELECT DISTINCT facility, phone, fax, destruction_policy FROM ddp_onc_history_detail WHERE facility LIKE ? AND NOT (deleted <=> 1)";
     private static final String SQL_SELECT_FACILITY_IN_GROUP = "SELECT DISTINCT oD.facility, oD.phone, oD.fax, oD.destruction_policy, realm.ddp_instance_id " +
             "FROM ddp_onc_history_detail oD " +
-            "LEFT JOIN ddp_medical_record m on (m.medical_record_id = oD.medical_record_id) " +
+            "LEFT JOIN ddp_medical_record m on (m.medical_record_id = oD.medical_record_id AND NOT m.deleted <=> 1) " +
             "LEFT JOIN ddp_institution inst on (m.institution_id = inst.institution_id) " +
             "LEFT JOIN  ddp_participant p on (p.participant_id = inst.participant_id) " +
             "LEFT JOIN ddp_instance realm on (p.ddp_instance_id = realm.ddp_instance_id) " +
@@ -51,7 +51,7 @@ public class LookupRoute extends RequestHandler {
 
     private static final String SQL_SELECT_HISTOLOGY = "SELECT DISTINCT histology FROM ddp_onc_history_detail onc, ddp_medical_record rec, ddp_institution inst, ddp_participant part," +
             " ddp_instance realm WHERE onc.medical_record_id = rec.medical_record_id AND rec.institution_id = inst.institution_id AND inst.participant_id = part.participant_id" +
-            " AND realm.ddp_instance_id = part.ddp_instance_id AND onc.histology LIKE ? AND realm.instance_name = ?";
+            " AND NOT rec.deleted <=> 1 AND realm.ddp_instance_id = part.ddp_instance_id AND onc.histology LIKE ? AND realm.instance_name = ?";
 
     private static final String MEDICAL_RECORD_CONTACT = "mrContact";
     private static final String TISSUE_FACILITY = "tFacility";

--- a/src/main/java/org/broadinstitute/dsm/util/DDPMedicalRecordDataRequest.java
+++ b/src/main/java/org/broadinstitute/dsm/util/DDPMedicalRecordDataRequest.java
@@ -32,7 +32,7 @@ public class DDPMedicalRecordDataRequest {
     private static final String SQL_SELECT_MEDICAL_RECORD_LOG = "SELECT rec.medical_record_id, log.type, log.date FROM ddp_medical_record rec " +
             "LEFT JOIN ddp_institution inst on (rec.institution_id = inst.institution_id) LEFT JOIN ddp_participant part on (part.participant_id = inst.participant_id) " +
             "LEFT JOIN ddp_medical_record_log log on (log.medical_record_id = rec.medical_record_id) WHERE part.ddp_participant_id = ? AND part.ddp_instance_id = ? " +
-            "AND rec.fax_sent is not null AND (log.type is null OR log.type = ?)";
+            "AND NOT rec.deleted <=> 1 AND rec.fax_sent is not null AND (log.type is null OR log.type = ?)";
     private static final String SQL_SELECT_LOG_FOR_MEDICAL_RECORD = "SELECT rec.medical_record_id, log.type, log.date, rec.fax_sent FROM ddp_medical_record rec " +
             "LEFT JOIN ddp_medical_record_log log on (log.medical_record_id = rec.medical_record_id) WHERE rec.medical_record_id = ? AND rec.fax_sent is not null " +
             "AND (log.type is null OR log.type = ?) ORDER BY medical_record_log_id desc";

--- a/src/main/java/org/broadinstitute/dsm/util/KitUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/KitUtil.java
@@ -51,7 +51,7 @@ public class KitUtil {
     private static final String SQL_SELECT_COLLABORATOR_ID_TISSUE = "SELECT tis.collaborator_sample_id FROM ddp_medical_record med " +
             "LEFT JOIN ddp_institution inst on (med.institution_id = inst.institution_id) LEFT JOIN ddp_participant as part on (part.participant_id = inst.participant_id) " +
             "LEFT JOIN ddp_onc_history_detail onc on (med.medical_record_id = onc.medical_record_id) LEFT JOIN ddp_tissue tis on (tis.onc_history_detail_id = onc.onc_history_detail_id) " +
-            "WHERE part.ddp_participant_id = ? AND part.ddp_instance_id = ? AND tis.collaborator_sample_id IS NOT NULL LIMIT 1";
+            "WHERE NOT med.deleted <=> 1 AND part.ddp_participant_id = ? AND part.ddp_instance_id = ? AND tis.collaborator_sample_id IS NOT NULL LIMIT 1";
     private static final String SQL_UPDATE_COLLABORATOR_IDS = "UPDATE ddp_kit_request set bsp_collaborator_participant_id = ?, bsp_collaborator_sample_id = ? WHERE dsm_kit_request_id = ?";
     public static final String SQL_UPDATE_KIT_RECEIVED = "UPDATE ddp_kit kit INNER JOIN( SELECT dsm_kit_request_id, MAX(dsm_kit_id) AS kit_id " +
             "FROM ddp_kit GROUP BY dsm_kit_request_id) groupedKit ON kit.dsm_kit_request_id = groupedKit.dsm_kit_request_id " +

--- a/src/main/java/org/broadinstitute/dsm/util/MedicalRecordUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/MedicalRecordUtil.java
@@ -27,9 +27,9 @@ public class MedicalRecordUtil {
     private static final String SQL_SELECT_PARTICIPANT_EXISTS = "SELECT count(ddp_participant_id) as participantCount FROM ddp_participant WHERE ddp_participant_id = ? AND ddp_instance_id = ?";
     private static final String SQL_SELECT_PARTICIPANT_LAST_VERSION = "SELECT last_version FROM ddp_participant WHERE ddp_participant_id = ? AND ddp_instance_id = ?";
     private static final String SQL_SELECT_MEDICAL_RECORD_ID_FOR_PARTICIPANT = "SELECT rec.medical_record_id FROM ddp_institution inst, ddp_participant part, ddp_medical_record rec " +
-            "WHERE part.participant_id = inst.participant_id AND rec.institution_id = inst.institution_id AND part.ddp_participant_id = ? AND inst.ddp_institution_id = ? AND part.ddp_instance_id = ? AND inst.type = ?";
+            "WHERE part.participant_id = inst.participant_id AND rec.institution_id = inst.institution_id AND NOT rec.deleted <=> 1 AND part.ddp_participant_id = ? AND inst.ddp_institution_id = ? AND part.ddp_instance_id = ? AND inst.type = ?";
     private static final String SQL_SELECT_MEDICAL_RECORD_ID_AND_TYPE_FOR_PARTICIPANT = "SELECT rec.medical_record_id, inst.type FROM ddp_institution inst, ddp_participant part, ddp_medical_record rec " +
-            "WHERE part.participant_id = inst.participant_id AND rec.institution_id = inst.institution_id AND part.participant_id = ? AND inst.type = ?";
+            "WHERE part.participant_id = inst.participant_id AND rec.institution_id = inst.institution_id AND NOT rec.deleted <=> 1 AND part.participant_id = ? AND inst.type = ?";
 
     public static final String SYSTEM = "SYSTEM";
     public static final String NOT_SPECIFIED = "NOT_SPECIFIED";

--- a/src/main/resources/liquibase/042-updateDB.xml
+++ b/src/main/resources/liquibase/042-updateDB.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="simone" id="addingDeletedFlag">
+        <addColumn tableName="ddp_medical_record">
+            <column name="deleted" type="tinyint(1)"></column>
+        </addColumn>
+    </changeSet>
+    <changeSet author="simone" id="setDeletedFlag">
+        <sql>UPDATE ddp_medical_record as m, (
+                SELECT m.medical_record_id from ddp_medical_record m
+                left join ddp_institution i on (i.institution_id = m.institution_id)
+                left join ddp_participant p on (p.participant_id = i.participant_id)
+                left join ddp_instance realm on (p.ddp_instance_id = realm.ddp_instance_id)
+                where realm.instance_name = 'Prostate' and (p.ddp_participant_id like '1771332079%' OR p.ddp_participant_id like '-763171247%') and type = 'INITIAL_BIOPSY' and i.ddp_institution_id != '1' and i.institution_id &#60; 20000) as m2
+            SET m.deleted = 1 WHERE m2.medical_record_id = m.medical_record_id;</sql>
+    </changeSet>
+    <!-- prefix for gen2 prostate pts in dev: 1771332079 on prod: -763171247  -->
+    <!-- prod i.instance_id > 20000 are actual new added initial_biopsies for migrated pts  -->
+</databaseChangeLog>

--- a/src/main/resources/master-changelog.xml
+++ b/src/main/resources/master-changelog.xml
@@ -43,4 +43,5 @@
     <include file="liquibase/038-updateDB.xml" relativeToChangelogFile="true"/>
     <include file="liquibase/040-updateDB.xml" relativeToChangelogFile="true"/>
     <include file="liquibase/041-updateDB.xml" relativeToChangelogFile="true"/>
+    <include file="liquibase/042-updateDB.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>


### PR DESCRIPTION
adding a deleted flag to the duplicate initial biopsy 
deleting 688 institutions and their associated medical records manually seems scary!

added the flag to all ddp_medical_record queries to ignore them

liquidbase update script to set the flag (only for institution_id < 20000 because of actual migrated pts with new added initial_biopsies)