### PR TITLE
DDP-5633 Retry UPS queries a few times before failing

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/shipping/UPSTracker.java
+++ b/src/main/java/org/broadinstitute/dsm/shipping/UPSTracker.java
@@ -51,12 +51,11 @@ public class UPSTracker {
             }
             catch (Exception e) {
                error = new RuntimeException("couldn't get response from ups tracking of package " + trackingId, e);
-               logger.error(error.getMessage(), e);
                logger.warn("Retrying ups round " + i);
                try {
                    Thread.sleep(5 * 1000);
                } catch (InterruptedException interrupted) {
-                   logger.error("Error while waiting for UPS retry", interrupted);
+                   logger.warn("Error while waiting for UPS retry", interrupted);
                }
             }
         }


### PR DESCRIPTION
The UPS tracking endpoint is a bit flakey.  This adds a few retry attempts before erroring out.  I've had these changes on a local branch and have been using them as part of manual kit report generation--they've definitely made things more robust, especially for long running jobs.