### PR TITLE
DDP-5639 message with study guid and DDP-5641 checking new role

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/db/EditParticipantMessage.java
+++ b/src/main/java/org/broadinstitute/dsm/db/EditParticipantMessage.java
@@ -31,9 +31,9 @@ public class EditParticipantMessage {
     private static final String SQL_INSERT_MESSAGE =
             "INSERT INTO " +
                     "message " +
-                    "(user_id, message_status, published_at) " +
+                    "(user_id, study_guid, message_status, published_at) " +
             "VALUES " +
-                    "(?, ?, ?)";
+                    "(?, ?, ?, ?)";
 
     private static final String SQL_UPDATE_MESSAGE =
             "UPDATE " +
@@ -55,13 +55,15 @@ public class EditParticipantMessage {
 
     private int messageId;
     private int userId;
+    private String studyGuid;
     private String messageStatus;
     private long published_at;
     private String received_message;
     private long received_at;
 
-    public EditParticipantMessage(int userId, String messageStatus, long published_at) {
+    public EditParticipantMessage(int userId, String studyGuid, String messageStatus, long published_at) {
         this.userId = userId;
+        this.studyGuid = studyGuid;
         this.messageStatus = messageStatus;
         this.published_at = published_at;
     }
@@ -86,6 +88,14 @@ public class EditParticipantMessage {
 
     public void setUserId(int userId) {
         this.userId = userId;
+    }
+
+    public String getStudyGuid() {
+        return studyGuid;
+    }
+
+    public void setStudyGuid(String studyGuid) {
+        this.studyGuid = studyGuid;
     }
 
     public String getMessageStatus() {
@@ -153,8 +163,9 @@ public class EditParticipantMessage {
             SimpleResult dbVals = new SimpleResult();
             try (PreparedStatement stmt = conn.prepareStatement(SQL_INSERT_MESSAGE)) {
                 stmt.setInt(1, message.getUserId());
-                stmt.setString(2, message.getMessageStatus());
-                stmt.setLong(3, message.getPublished_at());
+                stmt.setString(2, message.getStudyGuid());
+                stmt.setString(3, message.getMessageStatus());
+                stmt.setLong(4, message.getPublished_at());
                 int result = stmt.executeUpdate();
                 if (result == 1) {
                     logger.info("Added new message ");

--- a/src/main/java/org/broadinstitute/dsm/db/EditParticipantMessage.java
+++ b/src/main/java/org/broadinstitute/dsm/db/EditParticipantMessage.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsm.db;
 
+import lombok.Data;
 import lombok.NonNull;
 import org.broadinstitute.ddp.db.SimpleResult;
 import org.broadinstitute.dsm.statics.DBConstants;
@@ -14,6 +15,7 @@ import java.util.List;
 
 import static org.broadinstitute.ddp.db.TransactionWrapper.inTransaction;
 
+@Data
 public class EditParticipantMessage {
 
     private static final Logger logger = LoggerFactory.getLogger(EditParticipantMessage.class);
@@ -70,54 +72,6 @@ public class EditParticipantMessage {
         this.messageId = messageId;
         this.messageStatus = messageStatus;
         this.received_message = received_message;
-    }
-
-    public int getMessageId() {
-        return messageId;
-    }
-
-    public void setMessageId(int messageId) {
-        this.messageId = messageId;
-    }
-
-    public int getUserId() {
-        return userId;
-    }
-
-    public void setUserId(int userId) {
-        this.userId = userId;
-    }
-
-    public String getMessageStatus() {
-        return messageStatus;
-    }
-
-    public void setMessageStatus(String messageStatus) {
-        this.messageStatus = messageStatus;
-    }
-
-    public long getPublished_at() {
-        return published_at;
-    }
-
-    public void setPublished_at(long published_at) {
-        this.published_at = published_at;
-    }
-
-    public String getReceived_message() {
-        return received_message;
-    }
-
-    public void setReceived_message(String received_message) {
-        this.received_message = received_message;
-    }
-
-    public long getReceived_at() {
-        return received_at;
-    }
-
-    public void setReceived_at(long received_at) {
-        this.received_at = received_at;
     }
 
     public static EditParticipantMessage getMessageWithStatus(int userId) {

--- a/src/main/java/org/broadinstitute/dsm/db/EditParticipantMessage.java
+++ b/src/main/java/org/broadinstitute/dsm/db/EditParticipantMessage.java
@@ -31,9 +31,9 @@ public class EditParticipantMessage {
     private static final String SQL_INSERT_MESSAGE =
             "INSERT INTO " +
                     "message " +
-                    "(user_id, study_guid, message_status, published_at) " +
+                    "(user_id, message_status, published_at) " +
             "VALUES " +
-                    "(?, ?, ?, ?)";
+                    "(?, ?, ?)";
 
     private static final String SQL_UPDATE_MESSAGE =
             "UPDATE " +
@@ -55,15 +55,13 @@ public class EditParticipantMessage {
 
     private int messageId;
     private int userId;
-    private String studyGuid;
     private String messageStatus;
     private long published_at;
     private String received_message;
     private long received_at;
 
-    public EditParticipantMessage(int userId, String studyGuid, String messageStatus, long published_at) {
+    public EditParticipantMessage(int userId, String messageStatus, long published_at) {
         this.userId = userId;
-        this.studyGuid = studyGuid;
         this.messageStatus = messageStatus;
         this.published_at = published_at;
     }
@@ -88,14 +86,6 @@ public class EditParticipantMessage {
 
     public void setUserId(int userId) {
         this.userId = userId;
-    }
-
-    public String getStudyGuid() {
-        return studyGuid;
-    }
-
-    public void setStudyGuid(String studyGuid) {
-        this.studyGuid = studyGuid;
     }
 
     public String getMessageStatus() {
@@ -163,9 +153,8 @@ public class EditParticipantMessage {
             SimpleResult dbVals = new SimpleResult();
             try (PreparedStatement stmt = conn.prepareStatement(SQL_INSERT_MESSAGE)) {
                 stmt.setInt(1, message.getUserId());
-                stmt.setString(2, message.getStudyGuid());
-                stmt.setString(3, message.getMessageStatus());
-                stmt.setLong(4, message.getPublished_at());
+                stmt.setString(2, message.getMessageStatus());
+                stmt.setLong(3, message.getPublished_at());
                 int result = stmt.executeUpdate();
                 if (result == 1) {
                     logger.info("Added new message ");

--- a/src/main/java/org/broadinstitute/dsm/pubsub/EditParticipantMessagePublisher.java
+++ b/src/main/java/org/broadinstitute/dsm/pubsub/EditParticipantMessagePublisher.java
@@ -45,7 +45,6 @@ public class EditParticipantMessagePublisher {
             // Once published, returns a server-assigned message id (unique within the topic)
             ApiFuture<String> future = publisher.publish(pubsubMessage);
             EditParticipantMessage.insertMessage(new EditParticipantMessage(Integer.parseInt(attributeMap.get("userId")),
-                    attributeMap.get("studyGuid"),
                     DBConstants.MESSAGE_PUBLISHING_STATUS, System.currentTimeMillis()));
 
             // Add an asynchronous callback to handle success / failure

--- a/src/main/java/org/broadinstitute/dsm/pubsub/EditParticipantMessagePublisher.java
+++ b/src/main/java/org/broadinstitute/dsm/pubsub/EditParticipantMessagePublisher.java
@@ -45,6 +45,7 @@ public class EditParticipantMessagePublisher {
             // Once published, returns a server-assigned message id (unique within the topic)
             ApiFuture<String> future = publisher.publish(pubsubMessage);
             EditParticipantMessage.insertMessage(new EditParticipantMessage(Integer.parseInt(attributeMap.get("userId")),
+                    attributeMap.get("studyGuid"),
                     DBConstants.MESSAGE_PUBLISHING_STATUS, System.currentTimeMillis()));
 
             // Add an asynchronous callback to handle success / failure

--- a/src/main/java/org/broadinstitute/dsm/pubsub/PubSubResultMessageSubscription.java
+++ b/src/main/java/org/broadinstitute/dsm/pubsub/PubSubResultMessageSubscription.java
@@ -38,13 +38,14 @@ public class PubSubResultMessageSubscription {
                     String message = transformMessage(pubsubMessage);
                     JsonObject jsonObject = new Gson().fromJson(message, JsonObject.class);
                     String userId = null;
+
+                    consumer.ack();
+
                     if (jsonObject.has("userId")) {
                         userId = jsonObject.get("userId").getAsString();
                         EditParticipantMessage.updateMessage(Integer.parseInt(userId), DBConstants.MESSAGE_RECEIVED_STATUS,
                                 message, System.currentTimeMillis());
                     }
-
-                    consumer.ack();
                 };
 
         //Subscriber subscriber = null;

--- a/src/main/java/org/broadinstitute/dsm/route/EditParticipantPublisherRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/EditParticipantPublisherRoute.java
@@ -41,7 +41,7 @@ public class EditParticipantPublisherRoute extends RequestHandler {
             realm = queryParams.get(RoutePath.REALM).value();
         }
 
-        if (UserUtil.checkUserAccess(realm, userId, "mr_view") || UserUtil.checkUserAccess(realm, userId, "pt_list_view")) {
+        if (UserUtil.checkUserAccess(realm, userId, "participant_edit")) {
             String messageData = request.body();
 
             if (StringUtils.isBlank(messageData)) {

--- a/src/main/java/org/broadinstitute/dsm/route/EditParticipantPublisherRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/EditParticipantPublisherRoute.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.handlers.util.Result;
+import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.pubsub.EditParticipantMessagePublisher;
 import org.broadinstitute.dsm.security.RequestHandler;
 import org.broadinstitute.dsm.statics.RoutePath;
@@ -71,7 +72,8 @@ public class EditParticipantPublisherRoute extends RequestHandler {
 
     public static Map<String, String> getStringStringMap(String userId, JsonObject messageJsonObject) {
         String participantGuid = messageJsonObject.get("participantGuid").getAsString();
-        String studyGuid = messageJsonObject.get("studyGuid").getAsString();
+        String instanceName = messageJsonObject.get("instanceName").getAsString();
+        String studyGuid = DDPInstance.getStudyGuidByInstanceName(instanceName);
         Map<String, String> attributeMap = new HashMap<>();
         attributeMap.put("taskType", "UPDATE_PROFILE");
         attributeMap.put("userId", userId);

--- a/src/main/resources/liquibase/044-updateDB.xml
+++ b/src/main/resources/liquibase/044-updateDB.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="ikhaladz" id="addingStudyGuid">
+        <addColumn tableName="message">
+            <column name="study_guid" type="VARCHAR(200)"
+                afterColumn="user_id"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/044-updateDB.xml
+++ b/src/main/resources/liquibase/044-updateDB.xml
@@ -6,9 +6,9 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet author="ikhaladz" id="addingStudyGuid">
-        <addColumn tableName="message">
+        <addColumn tableName="ddp_instance">
             <column name="study_guid" type="VARCHAR(200)"
-                afterColumn="user_id"/>
+                afterColumn="instance_name"/>
         </addColumn>
     </changeSet>
 

--- a/src/main/resources/master-changelog.xml
+++ b/src/main/resources/master-changelog.xml
@@ -45,4 +45,5 @@
     <include file="liquibase/041-updateDB.xml" relativeToChangelogFile="true"/>
     <include file="liquibase/042-updateDB.xml" relativeToChangelogFile="true"/>
     <include file="liquibase/043-updateDB.xml" relativeToChangelogFile="true"/>
+    <include file="liquibase/044-updateDB.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>


### PR DESCRIPTION
Added new column study_guid in ddp_instance. After I get instance name from front, I'm getting study guid of this instance from ddp_instance and adding it to the message. Also added lombok Data annotation instead of getters and setters and in subscriber I decided to ack before update a message to avoid unlikely, but possible issue.
To make this changes work, we need to fill the study guids in database and give permissions to the user's we want to have ability to edit participant.