### PR TITLE
DDP-5446 | changed visual of error message, extracted exceptions, whi…

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -65,7 +65,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -682,6 +681,8 @@ public class DSMServer extends BasicServer {
             if (config.hasPath("slack.hook") && config.hasPath("slack.channel")) {
                 String appEnv = config.getString("portal.environment");
                 String slackHookUrlString = config.getString("slack.hook");
+                String gcpServiceName = config.getString("slack.gcpServiceName");
+                String rootPackage = DSMServer.class.getPackageName();
                 URI slackHookUrl;
                 String slackChannel = config.getString("slack.channel");
                 try {
@@ -689,7 +690,7 @@ public class DSMServer extends BasicServer {
                 } catch (URISyntaxException e) {
                     throw new IllegalArgumentException("Could not parse " + slackHookUrlString + "\n" + e);
                 }
-                SlackAppender.configure(schedulerName, appEnv, slackHookUrl, slackChannel);
+                SlackAppender.configure(schedulerName, appEnv, slackHookUrl, slackChannel, gcpServiceName, rootPackage);
                 logger.info("Error notification setup complete. If log4j.xml is configured, notifications will be sent to " + slackChannel + ".");
             } else {
                 logger.warn("Skipping error notification setup.");

--- a/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
+++ b/src/main/java/org/broadinstitute/dsm/log/SlackAppender.java
@@ -86,6 +86,11 @@ public class SlackAppender extends AppenderSkeleton {
         return gcpErrorsUri.toString();
     }
 
+    String buildGcpLogQuery() {
+        StringBuilder queryWithSeparator = new StringBuilder("");
+        return null;
+    }
+
     String getErrorMessageAndLocation(LoggingEvent event) {
         StringBuilder errorCauseAndPlace = new StringBuilder();
         Throwable error = event.getThrowableInformation().getThrowable();

--- a/src/test/java/org/broadinstitute/dsm/log/SlackAppenderTest.java
+++ b/src/test/java/org/broadinstitute/dsm/log/SlackAppenderTest.java
@@ -12,7 +12,6 @@ import com.typesafe.config.ConfigValueFactory;
 import org.apache.log4j.Level;
 import org.apache.log4j.spi.LoggingEvent;
 import org.apache.log4j.spi.RootLogger;
-import org.broadinstitute.ddp.util.Utility;
 import org.broadinstitute.dsm.TestHelper;
 import org.junit.Assert;
 import org.junit.Before;
@@ -58,23 +57,25 @@ public class SlackAppenderTest extends TestHelper {
             String slackHookUrlString = cfg.getString("slack.hook");
             URI slackHookUrl;
             String slackChannel = cfg.getString("slack.channel");
+            String gcpServiceName = cfg.getString("slack.gcpServiceName");
             try {
                 slackHookUrl = new URI(slackHookUrlString);
             } catch (URISyntaxException e) {
                 throw new IllegalArgumentException("Could not parse " + slackHookUrlString);
             }
 
-            SlackAppender.configure(null, appEnv, slackHookUrl, slackChannel);
+            SlackAppender.configure(null, appEnv, slackHookUrl, slackChannel, gcpServiceName, TestHelper.class.getPackageName());
 
             slackAppender.doAppend(loggingEvent);
 
-            String note = String.format(
-                    "%s \n" +
-                    "This does NOT look like a job error. Non-job error reporting is throttled so you will only see 1 per %s minutes.",
-                    slackAppender.getErrorMessageAndLocation(loggingEvent), 30);
+            String note = slackAppender.buildMessage(
+                    slackAppender.getErrorMessageAndLocation(loggingEvent),
+                    slackAppender.buildLinkToGcpError(loggingEvent),
+                    slackAppender.NON_JOB_ERROR_MESSAGE
+            );
 
             SlackAppender.SlackMessagePayload error_alert =
-                    slackAppender.getSlackMessagePayload(Utility.getCurrentEpoch(), note);
+                    slackAppender.buildSlackMessageWithPayload(note);
 
             mockDDP.verify(request().withPath("/mock_slack_test").withBody(JsonBody.json(
                     new Gson().toJson(error_alert))));

--- a/src/test/java/org/broadinstitute/dsm/log/SlackAppenderTest.java
+++ b/src/test/java/org/broadinstitute/dsm/log/SlackAppenderTest.java
@@ -71,7 +71,8 @@ public class SlackAppenderTest extends TestHelper {
             String note = slackAppender.buildMessage(
                     slackAppender.getErrorMessageAndLocation(loggingEvent),
                     slackAppender.buildLinkToGcpError(loggingEvent),
-                    slackAppender.NON_JOB_ERROR_MESSAGE
+                    slackAppender.NON_JOB_ERROR_MESSAGE,
+                    slackAppender.buildLinkToGcpLog()
             );
 
             SlackAppender.SlackMessagePayload error_alert =


### PR DESCRIPTION
**Main purpose of changes:**

1. Not to have whole stack trace in the message, only exceptions which are more or less understandable for developer.
2. Link to GCP Error page where developer can have a look at whole stack trace.
3. Link to GCP Logs page where developer can have a look at the logs 30 sec before and after the exception happened.

**What have been done:**

1. Used “root” package(hierarchical way), which is “org.broadinstitute.dsm”, because all the packages contains the same name, thus it made easier to catch the exceptions thrown by the code, which are placed in those packages.

2. Used “naive” approach of creating redirecting url to GCP Error page, with parameters “service” and “filter”, which helps to redirect user to GCP error page which is filtered by service and error (Unfortunately i could not found the better way to achieve this goal).
 
3. Because of strange url of GCP Log page, had to use "hard-coded" approach, first of all, used URIBuilder to create base url and then used StringBuilder to create whole url of GCP Logs, the reason why it has been done as "hard-coded" is that, some part of GCP Log url is encoded, another part is decoded, also it uses `;`(semi-colon) to separate query.

Made some code refactoring

How message looks like after changes:

![image](https://user-images.githubusercontent.com/75846598/108485483-65a72800-72b6-11eb-8f21-9044116c6448.png)

