### PR TITLE
DDP-5609 | feature add family member

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -523,6 +523,9 @@ public class DSMServer extends BasicServer {
         DrugListRoute drugListRoute = new DrugListRoute();
         get(UI_ROOT + RoutePath.FULL_DRUG_LIST_REQUEST, drugListRoute, new JsonTransformer());
         patch(UI_ROOT + RoutePath.FULL_DRUG_LIST_REQUEST, drugListRoute, new JsonTransformer());
+
+        AddFamilyMemberRoute addFamilyMemberRoute = new AddFamilyMemberRoute();
+        post(UI_ROOT + RoutePath.ADD_FAMILY_MEMBER, addFamilyMemberRoute, new JsonTransformer());
     }
 
     private void setupSharedRoutes(@NonNull KitUtil kitUtil, @NonNull NotificationUtil notificationUtil,

--- a/src/main/java/org/broadinstitute/dsm/db/dao/Dao.java
+++ b/src/main/java/org/broadinstitute/dsm/db/dao/Dao.java
@@ -1,0 +1,8 @@
+package org.broadinstitute.dsm.db.dao;
+
+public interface Dao<T> {
+
+    int create(T t);
+
+    int delete(int id);
+}

--- a/src/main/java/org/broadinstitute/dsm/db/dao/ddp/instance/DDPInstanceDao.java
+++ b/src/main/java/org/broadinstitute/dsm/db/dao/ddp/instance/DDPInstanceDao.java
@@ -1,0 +1,99 @@
+package org.broadinstitute.dsm.db.dao.ddp.instance;
+
+import org.broadinstitute.ddp.db.SimpleResult;
+import org.broadinstitute.dsm.db.dao.Dao;
+import org.broadinstitute.dsm.db.dto.ddp.instance.DDPInstanceDto;
+
+import static org.broadinstitute.ddp.db.TransactionWrapper.inTransaction;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+
+public class DDPInstanceDao implements Dao<DDPInstanceDto> {
+
+    private static final String SQL_INSERT_DDP_INSTANCE = "INSERT INTO ddp_instance SET " +
+            "instance_name = ?, " +
+            "study_guid = ?," +
+            "display_name = ?," +
+            "base_url = ?," +
+            "is_active = ?," +
+            "bsp_group = ?," +
+            "bsp_collection = ?," +
+            "bsp_organism = ?," +
+            "collaborator_id_prefix = ?," +
+            "reminder_notification_wks = ?," +
+            "mr_attention_flag_d = ?," +
+            "tissue_attention_flag_d = ?," +
+            "auth0_token = ?," +
+            "notification_recipients = ?," +
+            "migrated_ddp = ?," +
+            "billing_reference = ?," +
+            "es_participant_index = ?," +
+            "es_activity_definition_index = ?," +
+            "es_users_index = ?";
+
+    private static final String SQL_DELETE_DDP_INSTANCE = "DELETE FROM ddp_instance WHERE ddp_instance_id = ?";
+
+    @Override
+    public int create(DDPInstanceDto ddpInstanceDto) {
+        SimpleResult simpleResult = inTransaction(conn -> {
+            SimpleResult dbVals = new SimpleResult(-1);
+            try (PreparedStatement stmt = conn.prepareStatement(SQL_INSERT_DDP_INSTANCE, Statement.RETURN_GENERATED_KEYS)) {
+                stmt.setString(1, ddpInstanceDto.getInstanceName());
+                stmt.setString(2, ddpInstanceDto.getStudyGuid());
+                stmt.setString(3, ddpInstanceDto.getDisplayName());
+                stmt.setString(4, ddpInstanceDto.getBaseUrl());
+                stmt.setBoolean(5, ddpInstanceDto.getIsActive());
+                stmt.setString(6, ddpInstanceDto.getBspGroup());
+                stmt.setString(7, ddpInstanceDto.getBspCollection());
+                stmt.setString(8, ddpInstanceDto.getBspOrganism());
+                stmt.setString(9, ddpInstanceDto.getCollaboratorIdPrefix());
+                stmt.setObject(10, ddpInstanceDto.getReminderNotificationWks());
+                stmt.setObject(11, ddpInstanceDto.getMrAttentionFlagD());
+                stmt.setObject(12, ddpInstanceDto.getTissueAttentionFlagD());
+                stmt.setBoolean(13, ddpInstanceDto.getAuth0Token());
+                stmt.setString(14, ddpInstanceDto.getNotificiationRecipients());
+                stmt.setBoolean(15, ddpInstanceDto.getMigratedDdp());
+                stmt.setString(16, ddpInstanceDto.getBillingReference());
+                stmt.setString(17, ddpInstanceDto.getEsParticipantIndex());
+                stmt.setString(18, ddpInstanceDto.getEsActivityDefinitionIndex());
+                stmt.setString(19, ddpInstanceDto.getEsUsersIndex());
+                stmt.executeUpdate();
+                try (ResultSet rs = stmt.getGeneratedKeys()) {
+                    if (rs.next()) {
+                        dbVals.resultValue = rs.getInt(1);
+                    }
+                }
+            } catch (SQLException sqle) {
+                dbVals.resultException = sqle;
+            }
+            return dbVals;
+        });
+        if (simpleResult.resultException != null) {
+            throw new RuntimeException("Error inserting ddp instance ", simpleResult.resultException);
+        }
+        return (int) simpleResult.resultValue;
+    }
+
+    @Override
+    public int delete(int id) {
+        SimpleResult simpleResult = inTransaction(conn -> {
+            SimpleResult execResult = new SimpleResult();
+            try (PreparedStatement stmt = conn.prepareStatement(SQL_DELETE_DDP_INSTANCE)) {
+                stmt.setInt(1, id);
+                execResult.resultValue = stmt.executeUpdate();
+            } catch (SQLException sqle) {
+                execResult.resultException = sqle;
+            }
+            return execResult;
+        });
+
+        if (simpleResult.resultException != null) {
+            throw new RuntimeException("Error deleting ddp instance ", simpleResult.resultException);
+        }
+        return (int) simpleResult.resultValue;
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/db/dao/participant/data/ParticipantDataDao.java
+++ b/src/main/java/org/broadinstitute/dsm/db/dao/participant/data/ParticipantDataDao.java
@@ -1,0 +1,40 @@
+package org.broadinstitute.dsm.db.dao.participant.data;
+
+import static org.broadinstitute.ddp.db.TransactionWrapper.inTransaction;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.broadinstitute.ddp.db.SimpleResult;
+import org.broadinstitute.dsm.db.ParticipantData;
+import org.broadinstitute.dsm.db.dao.Dao;
+
+public class ParticipantDataDao implements Dao<ParticipantData> {
+
+    private static final String SQL_DELETE_DDP_PARTICIPANT_DATA = "DELETE FROM ddp_participant_data WHERE participant_data_id = ?";
+
+    @Override
+    public int create(ParticipantData participantData) {
+        return 0;
+    }
+
+    @Override
+    public int delete(int id) {
+        SimpleResult results = inTransaction((conn) -> {
+            SimpleResult execResult = new SimpleResult();
+            try (PreparedStatement stmt = conn.prepareStatement(SQL_DELETE_DDP_PARTICIPANT_DATA)) {
+                stmt.setInt(1, id);
+                execResult.resultValue = stmt.executeUpdate();
+            }
+            catch (SQLException ex) {
+                execResult.resultException = ex;
+            }
+            return execResult;
+        });
+        if (results.resultException != null) {
+            throw new RuntimeException("Error deleting participant data with "
+                    + id, results.resultException);
+        }
+        return (int) results.resultValue;
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/db/dao/user/UserDao.java
+++ b/src/main/java/org/broadinstitute/dsm/db/dao/user/UserDao.java
@@ -1,0 +1,63 @@
+package org.broadinstitute.dsm.db.dao.user;
+
+import static org.broadinstitute.ddp.db.TransactionWrapper.inTransaction;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.broadinstitute.ddp.db.SimpleResult;
+import org.broadinstitute.dsm.db.User;
+import org.broadinstitute.dsm.db.dao.Dao;
+
+public class UserDao implements Dao<User> {
+
+    private static final String SQL_INSERT_USER = "INSERT INTO access_user (name, email) VALUES (?,?)";
+    private static final String SQL_DELETE_USER_BY_ID = "DELETE FROM access_user WHERE user_id = ?";
+
+    @Override
+    public int create(User user) {
+        SimpleResult results = inTransaction((conn) -> {
+            SimpleResult execResult = new SimpleResult();
+            try (PreparedStatement stmt = conn.prepareStatement(SQL_INSERT_USER, PreparedStatement.RETURN_GENERATED_KEYS)) {
+                stmt.setString(1, user.getName());
+                stmt.setString(2, user.getEmail());
+                stmt.executeUpdate();
+                try (ResultSet rs = stmt.getGeneratedKeys()) {
+                    if (rs.next()) {
+                        execResult.resultValue = rs.getInt(1);
+                    }
+                }
+            }
+            catch (SQLException ex) {
+                execResult.resultException = ex;
+            }
+            return execResult;
+        });
+        if (results.resultException != null) {
+            throw new RuntimeException("Error inserting user with "
+                    + user.getEmail(), results.resultException);
+        }
+        return (int) results.resultValue;
+    }
+
+    @Override
+    public int delete(int id) {
+        SimpleResult results = inTransaction((conn) -> {
+            SimpleResult execResult = new SimpleResult();
+            try (PreparedStatement stmt = conn.prepareStatement(SQL_DELETE_USER_BY_ID)) {
+                stmt.setInt(1, id);
+                execResult.resultValue = stmt.executeUpdate();
+            }
+            catch (SQLException ex) {
+                execResult.resultException = ex;
+            }
+            return execResult;
+        });
+        if (results.resultException != null) {
+            throw new RuntimeException("Error deleting user with "
+                    + id, results.resultException);
+        }
+        return (int) results.resultValue;
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/db/dto/ddp/instance/DDPInstanceDto.java
+++ b/src/main/java/org/broadinstitute/dsm/db/dto/ddp/instance/DDPInstanceDto.java
@@ -1,0 +1,83 @@
+package org.broadinstitute.dsm.db.dto.ddp.instance;
+
+import java.sql.Types;
+
+import lombok.Data;
+import lombok.NonNull;
+
+@Data
+public class DDPInstanceDto {
+
+    Integer ddpInstanceId;
+    String instanceName;
+    String studyGuid;
+    String displayName;
+    String baseUrl;
+    Boolean isActive;
+    String bspGroup;
+    String bspCollection;
+    String bspOrganism;
+    String collaboratorIdPrefix;
+    Integer reminderNotificationWks;
+    Integer mrAttentionFlagD;
+    Integer tissueAttentionFlagD;
+    Boolean auth0Token;
+    String notificiationRecipients;
+    Boolean migratedDdp;
+    String billingReference;
+    String esParticipantIndex;
+    String esActivityDefinitionIndex;
+    String esUsersIndex;
+
+
+    public DDPInstanceDto(String instanceName, String studyGuid, String displayName, String baseUrl, @NonNull Boolean isActive,
+                          String bspGroup, String bspCollection, String bspOrganism, String collaboratorIdPrefix,
+                          Integer reminderNotificationWks,
+                          Integer mrAttentionFlagD, Integer tissueAttentionFlagD, @NonNull Boolean auth0Token, String notificiationRecipients,
+                          @NonNull Boolean migratedDdp, String billingReference, String esParticipantIndex, String esActivityDefinitionIndex,
+                          String esUsersIndex) {
+        this.instanceName = instanceName;
+        this.studyGuid = studyGuid;
+        this.displayName = displayName;
+        this.baseUrl = baseUrl;
+        this.isActive = isActive;
+        this.bspGroup = bspGroup;
+        this.bspCollection = bspCollection;
+        this.bspOrganism = bspOrganism;
+        this.collaboratorIdPrefix = collaboratorIdPrefix;
+        this.reminderNotificationWks = reminderNotificationWks;
+        this.mrAttentionFlagD = mrAttentionFlagD;
+        this.tissueAttentionFlagD = tissueAttentionFlagD;
+        this.auth0Token = auth0Token;
+        this.notificiationRecipients = notificiationRecipients;
+        this.migratedDdp = migratedDdp;
+        this.billingReference = billingReference;
+        this.esParticipantIndex = esParticipantIndex;
+        this.esActivityDefinitionIndex = esActivityDefinitionIndex;
+        this.esUsersIndex = esUsersIndex;
+    }
+
+    public static DDPInstanceDto of(boolean isActive, boolean auth0Token, boolean migratedDdp) {
+        return new DDPInstanceDto(
+                null,
+                null,
+                null,
+                null,
+                isActive,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                auth0Token,
+                null,
+                migratedDdp,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/model/ParticipantWrapper.java
+++ b/src/main/java/org/broadinstitute/dsm/model/ParticipantWrapper.java
@@ -6,11 +6,9 @@ import com.google.gson.JsonParser;
 import lombok.Data;
 import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
-import org.broadinstitute.ddp.util.DeliveryAddress;
 import org.broadinstitute.dsm.db.*;
-import org.broadinstitute.dsm.model.ddp.DDPParticipant;
+import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
 import org.broadinstitute.dsm.statics.DBConstants;
-import org.broadinstitute.dsm.util.DDPRequestUtil;
 import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.ParticipantUtil;
 import org.slf4j.Logger;
@@ -87,7 +85,7 @@ public class ParticipantWrapper {
                 medicalRecords = MedicalRecord.getMedicalRecords(instance.getName());
                 oncHistoryDetails = OncHistoryDetail.getOncHistoryDetails(instance.getName());
             }
-            if (DDPInstance.getRole(instance.getName(), DBConstants.KIT_REQUEST_ACTIVATED)) { //only needed if study is shipping samples per DSM
+            if (DDPInstanceDao.getRole(instance.getName(), DBConstants.KIT_REQUEST_ACTIVATED)) { //only needed if study is shipping samples per DSM
                 kitRequests = KitRequestShipping.getKitRequests(instance, ORDER_AND_LIMIT);
             }
             Map<String, List<AbstractionActivity>> abstractionActivities = AbstractionActivity.getAllAbstractionActivityByRealm(instance.getName());
@@ -171,7 +169,7 @@ public class ParticipantWrapper {
             if (oncHistories == null && instance.isHasRole()) {
                 oncHistories = OncHistoryDetail.getOncHistoryDetails(instance.getName());
             }
-            if (kitRequests == null && DDPInstance.getRole(instance.getName(), DBConstants.KIT_REQUEST_ACTIVATED)) { //only needed if study is shipping samples per DSM
+            if (kitRequests == null && DDPInstanceDao.getRole(instance.getName(), DBConstants.KIT_REQUEST_ACTIVATED)) { //only needed if study is shipping samples per DSM
                 //get only kitRequests for the filtered pts
                 if (participantESData != null && !participantESData.isEmpty()) {
                     String filter = Arrays.stream(participantESData.keySet().toArray(new String[0])).collect(Collectors.joining("\",\""));

--- a/src/main/java/org/broadinstitute/dsm/model/ddp/AddFamilyMemberPayload.java
+++ b/src/main/java/org/broadinstitute/dsm/model/ddp/AddFamilyMemberPayload.java
@@ -1,0 +1,31 @@
+package org.broadinstitute.dsm.model.ddp;
+
+
+import java.util.Map;
+import java.util.Optional;
+
+import com.google.gson.annotations.SerializedName;
+
+public class AddFamilyMemberPayload {
+
+    private String participantGuid;
+    private String realm;
+    private FamilyMemberDetails data;
+    private Integer userId;
+
+    public Optional<String> getParticipantGuid() {
+        return Optional.ofNullable(participantGuid);
+    }
+
+    public Optional<String> getRealm() {
+        return Optional.ofNullable(realm);
+    }
+
+    public Optional<FamilyMemberDetails> getData() {
+        return Optional.ofNullable(data);
+    }
+
+    public Optional<Integer> getUserId() {
+        return Optional.ofNullable(userId);
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/model/ddp/AddFamilyMemberPayload.java
+++ b/src/main/java/org/broadinstitute/dsm/model/ddp/AddFamilyMemberPayload.java
@@ -13,6 +13,13 @@ public class AddFamilyMemberPayload {
     private FamilyMemberDetails data;
     private Integer userId;
 
+    public AddFamilyMemberPayload(String participantGuid, String realm, FamilyMemberDetails data, Integer userId) {
+        this.participantGuid = participantGuid;
+        this.realm = realm;
+        this.data = data;
+        this.userId = userId;
+    }
+
     public Optional<String> getParticipantGuid() {
         return Optional.ofNullable(participantGuid);
     }

--- a/src/main/java/org/broadinstitute/dsm/model/ddp/FamilyMemberDetails.java
+++ b/src/main/java/org/broadinstitute/dsm/model/ddp/FamilyMemberDetails.java
@@ -1,0 +1,22 @@
+package org.broadinstitute.dsm.model.ddp;
+
+import com.google.gson.annotations.SerializedName;
+
+public class FamilyMemberDetails {
+
+    @SerializedName(value = "DATSTAT_FIRSTNAME", alternate = "firstName")
+    private String firstName;
+
+    @SerializedName(value = "DATSTAT_LASTNAME", alternate = "lastName")
+    private String lastName;
+
+    @SerializedName(value = "MEMBER_TYPE", alternate = "memberType")
+    private String memberType;
+
+    @SerializedName(value = "FAMILY_ID", alternate = "familyId")
+    private Integer familyId;
+
+    @SerializedName(value = "COLLABORATOR_PARTICIPANT_ID", alternate = "collaboratorParticipantId")
+    private String collaboratorParticipantId;
+
+}

--- a/src/main/java/org/broadinstitute/dsm/model/ddp/FamilyMemberDetails.java
+++ b/src/main/java/org/broadinstitute/dsm/model/ddp/FamilyMemberDetails.java
@@ -1,7 +1,9 @@
 package org.broadinstitute.dsm.model.ddp;
 
 import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
 
+@Getter
 public class FamilyMemberDetails {
 
     @SerializedName(value = "DATSTAT_FIRSTNAME", alternate = "firstName")
@@ -14,9 +16,18 @@ public class FamilyMemberDetails {
     private String memberType;
 
     @SerializedName(value = "FAMILY_ID", alternate = "familyId")
-    private Integer familyId;
+    private String familyId;
 
     @SerializedName(value = "COLLABORATOR_PARTICIPANT_ID", alternate = "collaboratorParticipantId")
     private String collaboratorParticipantId;
 
+
+    public FamilyMemberDetails(String firstName, String lastName, String memberType, String familyId,
+                               String collaboratorParticipantId) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.memberType = memberType;
+        this.familyId = familyId;
+        this.collaboratorParticipantId = collaboratorParticipantId;
+    }
 }

--- a/src/main/java/org/broadinstitute/dsm/route/AddFamilyMemberRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/AddFamilyMemberRoute.java
@@ -22,7 +22,7 @@ public class AddFamilyMemberRoute extends RequestHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(AddFamilyMemberRoute.class);
 
-    private static final String FIELD_TYPE = "RGP_PARTICIPANTS";
+    static final String FIELD_TYPE = "RGP_PARTICIPANTS";
 
     @Override
     protected Object processRequest(Request request, Response response, String userId) throws Exception {

--- a/src/main/java/org/broadinstitute/dsm/route/AddFamilyMemberRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/AddFamilyMemberRoute.java
@@ -9,9 +9,11 @@ import org.broadinstitute.ddp.handlers.util.Result;
 import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.db.ParticipantData;
 import org.broadinstitute.dsm.db.User;
+import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
 import org.broadinstitute.dsm.model.ddp.AddFamilyMemberPayload;
 import org.broadinstitute.dsm.model.ddp.FamilyMemberDetails;
 import org.broadinstitute.dsm.security.RequestHandler;
+import org.broadinstitute.dsm.statics.DBConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.Request;
@@ -22,7 +24,7 @@ public class AddFamilyMemberRoute extends RequestHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(AddFamilyMemberRoute.class);
 
-    static final String FIELD_TYPE = "RGP_PARTICIPANTS";
+    static final String FIELD_TYPE = "_PARTICIPANTS";
 
     @Override
     protected Object processRequest(Request request, Response response, String userId) throws Exception {
@@ -34,11 +36,18 @@ public class AddFamilyMemberRoute extends RequestHandler {
 
         String realm =
                 addFamilyMemberPayload.getRealm().orElseThrow(() -> new NoSuchElementException("Realm is not provided"));
+        boolean isRealmAbleOfAddFamilyMember = DDPInstanceDao.getRole(realm, DBConstants.ADD_FAMILY_MEMBER);
+        if (!isRealmAbleOfAddFamilyMember) {
+            response.status(400);
+            logger.warn("Study : " + realm + " is not setup to add family member");
+            return new Result(400, "Study is not setup to add family member");
+        }
         String ddpInstanceId = DDPInstance.getDDPInstance(realm).getDdpInstanceId();
 
         Optional<FamilyMemberDetails> maybeFamilyMemberData = addFamilyMemberPayload.getData();
         if (maybeFamilyMemberData.isEmpty() || isFamilyMemberFieldsEmpty(maybeFamilyMemberData)) {
             response.status(400);
+            logger.warn("Family member information for participant : " + participantGuid + " is not provided");
             return new Result(400, "Family member information is not provided");
         }
         FamilyMemberDetails familyMemberData = addFamilyMemberPayload.getData().get();
@@ -49,7 +58,8 @@ public class AddFamilyMemberRoute extends RequestHandler {
             throw new RuntimeException("User id was not equal. User id in token " + userId + " user id in request " + uId);
         }
         try {
-            ParticipantData.createNewParticipantData(participantGuid, ddpInstanceId, FIELD_TYPE, gson.toJson(familyMemberData), User.getUser(uId).getEmail());
+            String fieldTypeId = realm.toUpperCase() + FIELD_TYPE;
+            ParticipantData.createNewParticipantData(participantGuid, ddpInstanceId, fieldTypeId, gson.toJson(familyMemberData), User.getUser(uId).getEmail());
             logger.info("Family member for participant " + participantGuid + " successfully created");
         } catch (Exception e) {
             throw new RuntimeException("Could not create family member " + e);

--- a/src/main/java/org/broadinstitute/dsm/route/AddFamilyMemberRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/AddFamilyMemberRoute.java
@@ -1,0 +1,59 @@
+package org.broadinstitute.dsm.route;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import org.broadinstitute.ddp.handlers.util.Result;
+import org.broadinstitute.dsm.db.DDPInstance;
+import org.broadinstitute.dsm.db.FieldSettings;
+import org.broadinstitute.dsm.db.ParticipantData;
+import org.broadinstitute.dsm.db.User;
+import org.broadinstitute.dsm.model.ddp.AddFamilyMemberPayload;
+import org.broadinstitute.dsm.model.ddp.FamilyMemberDetails;
+import org.broadinstitute.dsm.security.RequestHandler;
+import org.broadinstitute.dsm.statics.DBConstants;
+import org.broadinstitute.dsm.util.UserUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import spark.Request;
+import spark.Response;
+
+public class AddFamilyMemberRoute extends RequestHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(AddFamilyMemberRoute.class);
+
+    private static final String FIELD_TYPE = "RGP_PARTICIPANTS";
+
+    @Override
+    protected Object processRequest(Request request, Response response, String userId) throws Exception {
+        Gson gson = new Gson();
+        AddFamilyMemberPayload addFamilyMemberPayload = gson.fromJson(request.body(), AddFamilyMemberPayload.class);
+
+        String participantGuid = addFamilyMemberPayload.getParticipantGuid()
+                .orElseThrow(() -> new NoSuchElementException("Participant Guid is not provided"));
+
+        String realm =
+                addFamilyMemberPayload.getRealm().orElseThrow(() -> new NoSuchElementException("Realm is not provided"));
+        String ddpInstanceId = DDPInstance.getDDPInstance(realm).getDdpInstanceId();
+
+        FamilyMemberDetails familyMemberData =
+                addFamilyMemberPayload.getData().orElseThrow(() -> new NoSuchElementException("Family member information is not provided"));
+//        FamilyMemberDetails familyMemberDetails = gson.fromJson(gson.toJson(familyMemberData), FamilyMemberDetails.class);
+        Integer uId =
+                addFamilyMemberPayload.getUserId().orElseThrow(() -> new NoSuchElementException("User id is not provided"));
+        if (Integer.parseInt(userId) != uId) {
+            throw new RuntimeException("User id was not equal. User id in token " + userId + " user id in request " + uId);
+        }
+        try {
+            ParticipantData.createNewParticipantData(participantGuid, ddpInstanceId, FIELD_TYPE, gson.toJson(familyMemberData), User.getUser(uId).getEmail());
+            logger.info("Family member for participant " + participantGuid + " successfully created");
+        } catch (Exception e) {
+            throw new RuntimeException("Could not create family member " + e);
+        }
+        return new Result(200);
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/route/DisplaySettingsRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/DisplaySettingsRoute.java
@@ -121,6 +121,9 @@ public class DisplaySettingsRoute extends RequestHandler {
                         }
                     }
                 }
+                if (DDPInstance.getRole(instance.getName(), DBConstants.ADD_FAMILY_MEMBER)) {
+                    displaySettings.put("addFamilyMember", true);
+                }
                 return displaySettings;
             }
         }

--- a/src/main/java/org/broadinstitute/dsm/route/DisplaySettingsRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/DisplaySettingsRoute.java
@@ -4,6 +4,7 @@ import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.handlers.util.Result;
 import org.broadinstitute.dsm.db.*;
+import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
 import org.broadinstitute.dsm.model.KitRequestSettings;
 import org.broadinstitute.dsm.model.KitSubKits;
 import org.broadinstitute.dsm.model.ddp.PreferredLanguage;
@@ -93,7 +94,7 @@ public class DisplaySettingsRoute extends RequestHandler {
                         displaySettings.put("preferredLanguages", preferredLanguages);
                     }
                 }
-                if (DDPInstance.getRole(instance.getName(), DBConstants.KIT_REQUEST_ACTIVATED)) { //only needed if study is shipping samples per DSM
+                if (DDPInstanceDao.getRole(instance.getName(), DBConstants.KIT_REQUEST_ACTIVATED)) { //only needed if study is shipping samples per DSM
                     Map<Integer, KitRequestSettings> kitRequestSettingsMap = KitRequestSettings.getKitRequestSettings(instance.getDdpInstanceId());
                     if (kitRequestSettingsMap != null) {
                         List<KitType> kits = new ArrayList<>();
@@ -121,7 +122,7 @@ public class DisplaySettingsRoute extends RequestHandler {
                         }
                     }
                 }
-                if (DDPInstance.getRole(instance.getName(), DBConstants.ADD_FAMILY_MEMBER)) {
+                if (DDPInstanceDao.getRole(instance.getName(), DBConstants.ADD_FAMILY_MEMBER)) {
                     displaySettings.put("addFamilyMember", true);
                 }
                 return displaySettings;

--- a/src/main/java/org/broadinstitute/dsm/statics/DBConstants.java
+++ b/src/main/java/org/broadinstitute/dsm/statics/DBConstants.java
@@ -275,6 +275,7 @@ public class DBConstants {
     public static final String PDF_DOWNLOAD_CONSENT = "pdf_download_consent";
     public static final String PDF_DOWNLOAD_RELEASE = "pdf_download_release";
     public static final String PARTICIPANT_STATUS_ENDPOINT = "participant_status_endpoint";
+    public static final String ADD_FAMILY_MEMBER = "add_family_member";
 
     //user role
     public static final String MAILINGLIST_VIEW = "mailingList_view";

--- a/src/main/java/org/broadinstitute/dsm/statics/RoutePath.java
+++ b/src/main/java/org/broadinstitute/dsm/statics/RoutePath.java
@@ -102,6 +102,7 @@ public class RoutePath {
     public static final String ABSTRACTION = "abstraction";
     public static final String EDIT_PARTICIPANT = "editParticipant";
     public static final String EDIT_PARTICIPANT_MESSAGE = "editParticipantMessageStatus";
+    public static final String ADD_FAMILY_MEMBER = "addFamilyMember";
 
     public static String getRealm(Request request) {
         QueryParamsMap queryParams = request.queryMap();

--- a/src/main/java/org/broadinstitute/dsm/util/UserUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/UserUtil.java
@@ -111,7 +111,7 @@ public class UserUtil {
         return users;
     }
 
-    public void insertUser(@NonNull String name, @NonNull String email) {
+    public int insertUser(@NonNull String name, @NonNull String email) {
         SimpleResult results = inTransaction((conn) -> {
             SimpleResult dbVals = new SimpleResult();
             try (PreparedStatement insertStmt = conn.prepareStatement(SQL_INSERT_USER, Statement.RETURN_GENERATED_KEYS)) {
@@ -121,6 +121,7 @@ public class UserUtil {
                 try (ResultSet rs = insertStmt.getGeneratedKeys()) {
                     if (rs.next()) {
                         UserSettings.insertUserSetting(conn, rs.getInt(1));
+                        dbVals.resultValue = rs.getInt(1);
                     }
                 }
                 catch (Exception e) {
@@ -136,6 +137,8 @@ public class UserUtil {
         if (results.resultException != null) {
             throw new RuntimeException("Error getting list of realms ", results.resultException);
         }
+
+        return (int) results.resultValue;
     }
 
     public static String getUserId(Request request) {

--- a/src/main/resources/liquibase/045-updateDB.xml
+++ b/src/main/resources/liquibase/045-updateDB.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add_family_member" author="gmakhara">
+        <insert tableName="instance_role">
+            <column name="name" value="add_family_member"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/master-changelog.xml
+++ b/src/main/resources/master-changelog.xml
@@ -47,4 +47,5 @@
     <include file="liquibase/042-updateDB.xml" relativeToChangelogFile="true"/>
     <include file="liquibase/043-updateDB.xml" relativeToChangelogFile="true"/>
     <include file="liquibase/044-updateDB.xml" relativeToChangelogFile="true"/>
+    <include file="liquibase/045-updateDB.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/test/java/org/broadinstitute/dsm/route/AddFamilyMemberRouteTest.java
+++ b/src/test/java/org/broadinstitute/dsm/route/AddFamilyMemberRouteTest.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsm.route;
 
-import static org.broadinstitute.dsm.TestHelper.cfg;
 import static org.broadinstitute.dsm.TestHelper.setupDB;
 
 import java.util.HashMap;
@@ -8,36 +7,69 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 
 import com.google.gson.Gson;
-import com.typesafe.config.Config;
 import org.broadinstitute.ddp.handlers.util.Result;
+import org.broadinstitute.dsm.db.ParticipantData;
+import org.broadinstitute.dsm.db.User;
+import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
+import org.broadinstitute.dsm.db.dao.participant.data.ParticipantDataDao;
+import org.broadinstitute.dsm.db.dao.user.UserDao;
+import org.broadinstitute.dsm.db.dto.ddp.instance.DDPInstanceDto;
 import org.broadinstitute.dsm.model.ddp.AddFamilyMemberPayload;
 import org.broadinstitute.dsm.model.ddp.FamilyMemberDetails;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import spark.utils.StringUtils;
 
 public class AddFamilyMemberRouteTest {
-
-    private static Config localCfg;
 
     private static AddFamilyMemberRoute addFamilyMemberRoute;
 
     private static Gson gson;
 
-    private static String participantId = "RBMJW6ZIXVXBMXUX6M3Q";
-    private static String realm = "testboston";
-    private static Integer userId = 94;
-    private static Map<String, String> data = new HashMap<>();
+    private static final String participantId = "RBMJW6ZIXVXBMXUX6M3Q";
+
+    private static User user;
+
+    private static String ddpParticipantDataId;
+
+    private static final Map<String, String> data = new HashMap<>();
+
+    private static DDPInstanceDto ddpInstanceDto;
+    private static final DDPInstanceDao ddpInstanceDao = new DDPInstanceDao();
+
+    private static final UserDao userDao = new UserDao();
+
+    private static final ParticipantDataDao participantDataDao = new ParticipantDataDao();
 
     @BeforeClass
     public static void doFirst() {
         setupDB();
-        localCfg = cfg;
-
-        addFamilyMemberRoute = new AddFamilyMemberRoute();
         gson = new Gson();
+        addFamilyMemberRoute = new AddFamilyMemberRoute();
 
+        createTestDdpInstance();
+
+        createTestDsmUser();
+
+        createTestDataOfFamilyMember();
+
+    }
+
+    private static void createTestDdpInstance() {
+        ddpInstanceDto = DDPInstanceDto.of(true, true, true);
+        ddpInstanceDto.setInstanceName("AddFamilyMemberInstance");
+        int testCreatedInstanceId = ddpInstanceDao.create(ddpInstanceDto);
+        ddpInstanceDto.setDdpInstanceId(testCreatedInstanceId);
+    }
+
+    private static void createTestDsmUser() {
+        user = new User(null, "AddFamilyMemberUser", "addfamilymember@family.com");
+        user.setId(String.valueOf(userDao.create(user)));
+    }
+
+    private static void createTestDataOfFamilyMember() {
         data.put("firstName", "Family");
         data.put("lastName", "Member");
         data.put("memberType", "Sister");
@@ -45,14 +77,19 @@ public class AddFamilyMemberRouteTest {
         data.put("collaboratorParticipantId", "PE3LHB_1_2");
     }
 
+
     @AfterClass
     public static void finish() {
-
+        if (StringUtils.isNotBlank(ddpParticipantDataId)) {
+            participantDataDao.delete(Integer.parseInt(ddpParticipantDataId));
+        }
+        userDao.delete(user.getUserId());
+        ddpInstanceDao.delete(ddpInstanceDto.getDdpInstanceId());
     }
 
     @Test
     public void noGuidProvided() {
-        String payload = payloadFactory(null, realm, data, userId);
+        String payload = payloadFactory(null, ddpInstanceDto.getInstanceName(), data, user.getUserId());
         AddFamilyMemberPayload addFamilyMemberPayload = gson.fromJson(payload, AddFamilyMemberPayload.class);
         try {
             addFamilyMemberPayload.getParticipantGuid().orElseThrow(() -> new NoSuchElementException("Participant Guid is not provided"));
@@ -63,7 +100,7 @@ public class AddFamilyMemberRouteTest {
 
     @Test
     public void noRealmProvided() {
-        String payload = payloadFactory(participantId, null, data, userId);
+        String payload = payloadFactory(participantId, null, data, Integer.parseInt(user.getId()));
         AddFamilyMemberPayload addFamilyMemberPayload = gson.fromJson(payload, AddFamilyMemberPayload.class);
         try {
             addFamilyMemberPayload.getRealm().orElseThrow(() -> new NoSuchElementException("Realm is not provided"));
@@ -74,19 +111,19 @@ public class AddFamilyMemberRouteTest {
 
     @Test
     public void noFamilyMemberDataProvided(){
-        String payload = payloadFactory(participantId, realm, Map.of(), userId);
+        String payload = payloadFactory(participantId, ddpInstanceDto.getInstanceName(), Map.of(), user.getUserId());
         Result res = new Result(200);
         AddFamilyMemberPayload addFamilyMemberPayload = gson.fromJson(payload, AddFamilyMemberPayload.class);
         if (addFamilyMemberPayload.getData().isEmpty() || addFamilyMemberRoute.isFamilyMemberFieldsEmpty(addFamilyMemberPayload.getData())) {
             res = new Result(400, "Family member information is not provided");
         }
-        Assert.assertEquals(res.getCode(), 400);
-        Assert.assertEquals(res.getBody(), "Family member information is not provided");
+        Assert.assertEquals(400, res.getCode());
+        Assert.assertEquals("Family member information is not provided", res.getBody());
     }
 
     @Test
     public void noUserIdProvided() {
-        String payload = payloadFactory(participantId, realm, Map.of(), null);
+        String payload = payloadFactory(participantId, ddpInstanceDto.getInstanceName(), Map.of(), null);
         AddFamilyMemberPayload addFamilyMemberPayload = gson.fromJson(payload, AddFamilyMemberPayload.class);
         try {
             addFamilyMemberPayload.getUserId().orElseThrow(() -> new NoSuchElementException("User id is not provided"));
@@ -95,6 +132,24 @@ public class AddFamilyMemberRouteTest {
         }
     }
 
+    @Test
+    public void addFamilyMemberToParticipant() {
+        String payload = payloadFactory(participantId, ddpInstanceDto.getInstanceName(), data, user.getUserId());
+        Result result = new Result(200);
+        AddFamilyMemberPayload addFamilyMemberPayload = gson.fromJson(payload, AddFamilyMemberPayload.class);
+        try {
+            ddpParticipantDataId = ParticipantData.createNewParticipantData(
+                    addFamilyMemberPayload.getParticipantGuid().get(),
+                    String.valueOf(ddpInstanceDto.getDdpInstanceId()),
+                    AddFamilyMemberRoute.FIELD_TYPE,
+                    gson.toJson(addFamilyMemberPayload.getData().get()),
+                    user.getEmail()
+                    );
+        } catch (Exception e) {
+            result = new Result(500);
+        }
+        Assert.assertEquals(200, result.getCode());
+    }
 
     public static String payloadFactory(String participantGuid, String realm, Map<String, String> data, Integer userId) {
         FamilyMemberDetails familyMemberDetails;

--- a/src/test/java/org/broadinstitute/dsm/route/AddFamilyMemberRouteTest.java
+++ b/src/test/java/org/broadinstitute/dsm/route/AddFamilyMemberRouteTest.java
@@ -1,0 +1,117 @@
+package org.broadinstitute.dsm.route;
+
+import static org.broadinstitute.dsm.TestHelper.cfg;
+import static org.broadinstitute.dsm.TestHelper.setupDB;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import com.google.gson.Gson;
+import com.typesafe.config.Config;
+import org.broadinstitute.ddp.handlers.util.Result;
+import org.broadinstitute.dsm.model.ddp.AddFamilyMemberPayload;
+import org.broadinstitute.dsm.model.ddp.FamilyMemberDetails;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class AddFamilyMemberRouteTest {
+
+    private static Config localCfg;
+
+    private static AddFamilyMemberRoute addFamilyMemberRoute;
+
+    private static Gson gson;
+
+    private static String participantId = "RBMJW6ZIXVXBMXUX6M3Q";
+    private static String realm = "testboston";
+    private static Integer userId = 94;
+    private static Map<String, String> data = new HashMap<>();
+
+    @BeforeClass
+    public static void doFirst() {
+        setupDB();
+        localCfg = cfg;
+
+        addFamilyMemberRoute = new AddFamilyMemberRoute();
+        gson = new Gson();
+
+        data.put("firstName", "Family");
+        data.put("lastName", "Member");
+        data.put("memberType", "Sister");
+        data.put("familyId", "PE3LHB");
+        data.put("collaboratorParticipantId", "PE3LHB_1_2");
+    }
+
+    @AfterClass
+    public static void finish() {
+
+    }
+
+    @Test
+    public void noGuidProvided() {
+        String payload = payloadFactory(null, realm, data, userId);
+        AddFamilyMemberPayload addFamilyMemberPayload = gson.fromJson(payload, AddFamilyMemberPayload.class);
+        try {
+            addFamilyMemberPayload.getParticipantGuid().orElseThrow(() -> new NoSuchElementException("Participant Guid is not provided"));
+        } catch (NoSuchElementException nsee) {
+            Assert.assertEquals("Participant Guid is not provided", nsee.getMessage());
+        }
+    }
+
+    @Test
+    public void noRealmProvided() {
+        String payload = payloadFactory(participantId, null, data, userId);
+        AddFamilyMemberPayload addFamilyMemberPayload = gson.fromJson(payload, AddFamilyMemberPayload.class);
+        try {
+            addFamilyMemberPayload.getRealm().orElseThrow(() -> new NoSuchElementException("Realm is not provided"));
+        } catch (NoSuchElementException nsee) {
+            Assert.assertEquals("Realm is not provided", nsee.getMessage());
+        }
+    }
+
+    @Test
+    public void noFamilyMemberDataProvided(){
+        String payload = payloadFactory(participantId, realm, Map.of(), userId);
+        Result res = new Result(200);
+        AddFamilyMemberPayload addFamilyMemberPayload = gson.fromJson(payload, AddFamilyMemberPayload.class);
+        if (addFamilyMemberPayload.getData().isEmpty() || addFamilyMemberRoute.isFamilyMemberFieldsEmpty(addFamilyMemberPayload.getData())) {
+            res = new Result(400, "Family member information is not provided");
+        }
+        Assert.assertEquals(res.getCode(), 400);
+        Assert.assertEquals(res.getBody(), "Family member information is not provided");
+    }
+
+    @Test
+    public void noUserIdProvided() {
+        String payload = payloadFactory(participantId, realm, Map.of(), null);
+        AddFamilyMemberPayload addFamilyMemberPayload = gson.fromJson(payload, AddFamilyMemberPayload.class);
+        try {
+            addFamilyMemberPayload.getUserId().orElseThrow(() -> new NoSuchElementException("User id is not provided"));
+        } catch (NoSuchElementException nsee) {
+            Assert.assertEquals("User id is not provided", nsee.getMessage());
+        }
+    }
+
+
+    public static String payloadFactory(String participantGuid, String realm, Map<String, String> data, Integer userId) {
+        FamilyMemberDetails familyMemberDetails;
+        if (data == null) {
+            familyMemberDetails = null;
+        } else {
+            familyMemberDetails = new FamilyMemberDetails(
+                data.get("firstName"),
+                data.get("lastName"),
+                data.get("memberType"),
+                data.get("familyId"),
+                data.get("collaboratorParticipantId")
+            );
+        }
+        AddFamilyMemberPayload addFamilyMemberPayload = new AddFamilyMemberPayload(participantGuid, realm, familyMemberDetails, userId);
+
+        return gson.toJson(addFamilyMemberPayload);
+    }
+
+}


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/browse/DDP-5609

**Things have done:**

- added new instance role `add_family_member` using liquibase.
- added if instance has new role `add_family_member` to display settings `DisplaySettingsRoute.java:124`.
- added new route for adding family member data to participant `AddFamilyMemberRoute.java `.
- added two POJO class for family member payload json `AddFamilyMemberPayload.java`, `FamilyMemberDetails`.
- used Optional approach for validations for payload json to provide cleaner code for new add family member route.
- added high level Dao interface to provide general operations on database, created several Dao class implementing that interface, to provide cleaner design and useful for unit tests as well.
- added tests for add family member route, used `@BeforeClass`, `@AfterClass` annotations to setup and clean up environment for tests 