### PR TITLE
DDP-5713 | Default options for new family member

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/db/FieldSettings.java
+++ b/src/main/java/org/broadinstitute/dsm/db/FieldSettings.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.db.SimpleResult;
+import org.broadinstitute.dsm.db.dto.fieldsettings.FieldSettingsDto;
 import org.broadinstitute.dsm.model.Value;
 import org.broadinstitute.dsm.statics.DBConstants;
 import org.slf4j.Logger;
@@ -235,4 +236,5 @@ public class FieldSettings {
         }
         return values;
     }
+
 }

--- a/src/main/java/org/broadinstitute/dsm/db/dao/fieldsettings/FieldSettingsDao.java
+++ b/src/main/java/org/broadinstitute/dsm/db/dao/fieldsettings/FieldSettingsDao.java
@@ -1,0 +1,100 @@
+package org.broadinstitute.dsm.db.dao.fieldsettings;
+
+import static org.broadinstitute.ddp.db.TransactionWrapper.inTransaction;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.broadinstitute.ddp.db.SimpleResult;
+import org.broadinstitute.dsm.db.dao.Dao;
+import org.broadinstitute.dsm.db.dto.fieldsettings.FieldSettingsDto;
+
+public class FieldSettingsDao implements Dao<FieldSettingsDto> {
+
+    private static final String SQL_OPTIONS_BY_INSTANCE_ID = "SELECT " +
+            "field_settings_id," +
+            "ddp_instance_id," +
+            "field_type," +
+            "column_name," +
+            "column_display," +
+            "display_type," +
+            "possible_values," +
+            "actions," +
+            "order_number," +
+            "deleted," +
+            "last_changed," +
+            "changed_by" +
+            " FROM field_settings WHERE ddp_instance_id = ? and display_type = 'OPTIONS'";
+
+    private static final String FIELD_SETTINGS_ID = "field_settings_id";
+    private static final String DDP_INSTANCE_ID = "ddp_instance_id";
+    private static final String FIELD_TYPE = "field_type";
+    private static final String COLUMN_NAME = "column_name";
+    private static final String COLUMN_DISPLAY = "column_display";
+    private static final String DISPLAY_TYPE = "display_type";
+    private static final String POSSIBLE_VALUES = "possible_values";
+    private static final String ACTIONS = "actions";
+    private static final String ORDER_NUMBER = "order_number";
+    private static final String DELETED = "deleted";
+    private static final String LAST_CHANGED = "last_changed";
+    private static final String CHANGED_BY = "changed_by";
+
+    @Override
+    public int create(FieldSettingsDto fieldSettingsDto) {
+        return 0;
+    }
+
+    @Override
+    public int delete(int id) {
+        return 0;
+    }
+
+    @Override
+    public Optional<FieldSettingsDto> get(long id) {
+        return Optional.empty();
+    }
+
+    public List<FieldSettingsDto> getFieldSettingsByOptionAndInstanceId(int instanceId) {
+        List<FieldSettingsDto> fieldSettingsByOptions = new ArrayList<>();
+        SimpleResult results = inTransaction((conn) -> {
+            SimpleResult execResult = new SimpleResult();
+            try (PreparedStatement stmt = conn.prepareStatement(SQL_OPTIONS_BY_INSTANCE_ID)) {
+                stmt.setInt(1, instanceId);
+                try(ResultSet rs = stmt.executeQuery()) {
+                    while (rs.next()) {
+                        fieldSettingsByOptions.add(
+                                new FieldSettingsDto(
+                                        rs.getInt(FIELD_SETTINGS_ID),
+                                        rs.getInt(DDP_INSTANCE_ID),
+                                        rs.getString(FIELD_TYPE),
+                                        rs.getString(COLUMN_NAME),
+                                        rs.getString(COLUMN_DISPLAY),
+                                        rs.getString(DISPLAY_TYPE),
+                                        rs.getString(POSSIBLE_VALUES),
+                                        rs.getString(ACTIONS),
+                                        rs.getInt(ORDER_NUMBER),
+                                        rs.getBoolean(DELETED),
+                                        rs.getLong(LAST_CHANGED),
+                                        rs.getString(CHANGED_BY)
+                                )
+                        );
+                    }
+                }
+            }
+            catch (SQLException ex) {
+                execResult.resultException = ex;
+            }
+            return execResult;
+        });
+        if (results.resultException != null) {
+            throw new RuntimeException("Error getting fieldSettingsByOptions for instance id: "
+                    + instanceId, results.resultException);
+        }
+        return fieldSettingsByOptions;
+    }
+
+}

--- a/src/main/java/org/broadinstitute/dsm/db/dto/fieldsettings/FieldSettingsDto.java
+++ b/src/main/java/org/broadinstitute/dsm/db/dto/fieldsettings/FieldSettingsDto.java
@@ -1,0 +1,39 @@
+package org.broadinstitute.dsm.db.dto.fieldsettings;
+
+
+import lombok.Data;
+
+@Data
+public class FieldSettingsDto {
+
+    private int fieldSettingsId;
+    private int ddpInstanceId;
+    private String fieldType;
+    private String columnName;
+    private String columnDisplay;
+    private String displayType;
+    private String possibleValues;
+    private String actions;
+    private int orderNumber;
+    private boolean deleted;
+    private long lastChanged;
+    private String changedBy;
+
+    public FieldSettingsDto() {}
+    public FieldSettingsDto(int fieldSettingsId, int ddpInstanceId, String fieldType, String columnName, String columnDisplay,
+                            String displayType, String possibleValues, String actions, int orderNumber, boolean deleted, long lastChanged,
+                            String changedBy) {
+        this.fieldSettingsId = fieldSettingsId;
+        this.ddpInstanceId = ddpInstanceId;
+        this.fieldType = fieldType;
+        this.columnName = columnName;
+        this.columnDisplay = columnDisplay;
+        this.displayType = displayType;
+        this.possibleValues = possibleValues;
+        this.actions = actions;
+        this.orderNumber = orderNumber;
+        this.deleted = deleted;
+        this.lastChanged = lastChanged;
+        this.changedBy = changedBy;
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/model/fieldsettings/FieldSettings.java
+++ b/src/main/java/org/broadinstitute/dsm/model/fieldsettings/FieldSettings.java
@@ -1,0 +1,48 @@
+package org.broadinstitute.dsm.model.fieldsettings;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import lombok.NonNull;
+import org.broadinstitute.dsm.db.dto.fieldsettings.FieldSettingsDto;
+
+public class FieldSettings {
+
+    public static final String KEY_DEFAULT = "default";
+    public static final String KEY_VALUE = "value";
+
+    public Map<String, String> getColumnsWithDefaultOptions(@NonNull List<FieldSettingsDto> fieldSettingsDtos) {
+        Map<String, String> defaultOptions = new HashMap<>();
+        for (FieldSettingsDto fieldSettingDto: fieldSettingsDtos) {
+            if (isDefaultOption(fieldSettingDto.getPossibleValues())) {
+                defaultOptions.put(fieldSettingDto.getColumnName(), getDefaultOption(fieldSettingDto.getPossibleValues()));
+            }
+        }
+        return defaultOptions;
+    }
+
+    String getDefaultOption(String possibleValuesJson) {
+        List<Map<String, Object>> possibleValues = new Gson().fromJson(possibleValuesJson, List.class);
+
+        return (String) possibleValues.stream()
+                .filter(f -> ((Boolean) f.getOrDefault(KEY_DEFAULT, false)))
+                .findFirst()
+                .map(m -> m.getOrDefault(KEY_VALUE, ""))
+                .orElse("");
+    }
+
+    boolean isDefaultOption(String possibleValuesJson) {
+         List<Map<String, Object>> possibleValues = new Gson().fromJson(possibleValuesJson, List.class);
+         boolean isDefault = false;
+         for (Map<String, Object> opt: possibleValues) {
+             boolean hasDefault = opt.containsKey(KEY_DEFAULT);
+             if (hasDefault) {
+                 isDefault = (Boolean) opt.get(KEY_DEFAULT);
+             }
+         }
+         return isDefault;
+    }
+
+}

--- a/src/main/java/org/broadinstitute/dsm/model/participant/data/NewParticipantData.java
+++ b/src/main/java/org/broadinstitute/dsm/model/participant/data/NewParticipantData.java
@@ -13,8 +13,11 @@ import com.google.gson.reflect.TypeToken;
 import lombok.Data;
 import lombok.NonNull;
 import org.broadinstitute.dsm.db.dao.Dao;
+import org.broadinstitute.dsm.db.dao.fieldsettings.FieldSettingsDao;
 import org.broadinstitute.dsm.db.dao.participant.data.ParticipantDataDao;
+import org.broadinstitute.dsm.db.dto.fieldsettings.FieldSettingsDto;
 import org.broadinstitute.dsm.db.dto.participant.data.ParticipantDataDto;
+import org.broadinstitute.dsm.model.fieldsettings.FieldSettings;
 
 @Data
 public class NewParticipantData {
@@ -79,6 +82,12 @@ public class NewParticipantData {
         //after self/proband data has been put into mergedData, to replace self/proband's [FIRSTNAME, LASTNAME, MEMBER_TYPE...] values by new family member's data
         mergedData.putAll(familyMemberData.toMap());
         return mergedData;
+    }
+
+    public void addDefaultOptionsValueToData(@NonNull Map<String, String> columnsWithDefaultOptions) {
+        columnsWithDefaultOptions.forEach((column, option) -> {
+            this.data.putIfAbsent(column, option);
+        });
     }
 
     public void setData(String ddpParticipantId, int ddpInstanceId, String fieldTypeId, Map<String, String> data) {

--- a/src/main/java/org/broadinstitute/dsm/route/familymember/AddFamilyMemberRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/familymember/AddFamilyMemberRoute.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsm.route.familymember;
 
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
@@ -8,7 +9,9 @@ import org.broadinstitute.ddp.handlers.util.Result;
 import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.db.User;
 import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
+import org.broadinstitute.dsm.db.dao.fieldsettings.FieldSettingsDao;
 import org.broadinstitute.dsm.db.dao.participant.data.ParticipantDataDao;
+import org.broadinstitute.dsm.model.fieldsettings.FieldSettings;
 import org.broadinstitute.dsm.model.participant.data.NewParticipantData;
 import org.broadinstitute.dsm.model.participant.data.AddFamilyMemberPayload;
 import org.broadinstitute.dsm.model.participant.data.FamilyMemberDetails;
@@ -58,19 +61,26 @@ public class AddFamilyMemberRoute extends RequestHandler {
 
         ParticipantDataDao participantDataDao = new ParticipantDataDao();
         try {
-            NewParticipantData participantDateObject = new NewParticipantData(participantDataDao);
-            participantDateObject.setData(
+            NewParticipantData participantDataObject = new NewParticipantData(participantDataDao);
+            participantDataObject.setData(
                     participantGuid,
                     Integer.parseInt(ddpInstanceId),
                     realm.toUpperCase() + FIELD_TYPE,
-                    participantDateObject.mergeParticipantData(addFamilyMemberPayload)
+                    participantDataObject.mergeParticipantData(addFamilyMemberPayload)
                     );
-            participantDateObject.insertParticipantData(User.getUser(uId).getEmail());
+            participantDataObject.addDefaultOptionsValueToData(getDefaultOptions(Integer.parseInt(ddpInstanceId)));
+            participantDataObject.insertParticipantData(User.getUser(uId).getEmail());
             logger.info("Family member for participant " + participantGuid + " successfully created");
         } catch (Exception e) {
             throw new RuntimeException("Could not create family member " + e);
         }
         return NewParticipantData.parseDtoList(participantDataDao.getParticipantDataByParticipantId(participantGuid));
+    }
+
+    private Map<String, String> getDefaultOptions(int ddpInstanceId) {
+        FieldSettingsDao fieldSettingsDao = new FieldSettingsDao();
+        FieldSettings fieldSettings = new FieldSettings();
+        return fieldSettings.getColumnsWithDefaultOptions(fieldSettingsDao.getFieldSettingsByOptionAndInstanceId(ddpInstanceId));
     }
 
 

--- a/src/test/java/org/broadinstitute/dsm/model/fieldsettings/FieldSettingsTest.java
+++ b/src/test/java/org/broadinstitute/dsm/model/fieldsettings/FieldSettingsTest.java
@@ -1,0 +1,61 @@
+package org.broadinstitute.dsm.model.fieldsettings;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.broadinstitute.dsm.db.dto.fieldsettings.FieldSettingsDto;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class FieldSettingsTest {
+
+    private static final String acceptanceStatusPossibleValue = "[{\"value\":\"ACCEPTED\",\"name\":\"Accepted\",default:true},{\"value\":\"IN_REVIEW\",\"name\":\"In Review\"},{\"name\":\"More Info Needed\",\"value\":\"MORE_INFO_NEEDED\"},{\"name\":\"Not Accepted\",\"value\":\"NOT_ACCEPTED\"},{\"name\":\"Waitlist\",\"value\":\"WAITLIST\"},{\"name\":\"Pre-review\",\"value\":\"PRE_REVIEW\"}]";
+    private static final String activePossibleValue = "[{\"value\":\"ACTIVE\",\"name\":\"Active\"},{\"value\":\"HOLD\",\"name\":\"HOLD\"},{\"value\":\"INACTIVE\",\"name\":\"Inactive\"}]";
+    private static final String ethnicityPossibleValue = "[{\"name\":\"Hispanic\",\"value\":\"HISPANIC\",default:true},{\"name\":\"Not Hispanic\",\"value\":\"NOT_HISPANIC\"},{\"name\":\"Unknown or Not Reported\",\"value\":\"UNKNOWN\"}]";
+    private static final String acceptanceStatusColumnName = "ACCEPTANCE_STATUS";
+    private static final String activeColumnName = "ACTIVE";
+    private static final String ethnicityColumnName = "ETHNICITY";
+
+    private static FieldSettings fieldSettings;
+
+    @BeforeClass
+    public static void first() {
+        fieldSettings = new FieldSettings();
+    }
+
+    @Test
+    public void testGetDefaultOption() {
+        String defaultOption = fieldSettings.getDefaultOption(acceptanceStatusPossibleValue);
+        Assert.assertEquals("ACCEPTED", defaultOption);
+    }
+
+    @Test
+    public void testIsDefaultOption() {
+        boolean isDefaultOption = fieldSettings.isDefaultOption(acceptanceStatusPossibleValue);
+        Assert.assertTrue(isDefaultOption);
+    }
+
+    @Test
+    public void testGetDefaultOptions() {
+        Map<String, String> defaultOptions = fieldSettings.getColumnsWithDefaultOptions(createStaticFieldSettingDtoList());
+        Assert.assertEquals("ACCEPTED", defaultOptions.get(acceptanceStatusColumnName));
+        Assert.assertEquals("HISPANIC", defaultOptions.get(ethnicityColumnName));
+        Assert.assertEquals(null, defaultOptions.get(activeColumnName));
+    }
+
+    List<FieldSettingsDto> createStaticFieldSettingDtoList() {
+        FieldSettingsDto fieldSettingsDto1 = new FieldSettingsDto();
+        fieldSettingsDto1.setColumnName(acceptanceStatusColumnName);
+        fieldSettingsDto1.setPossibleValues(acceptanceStatusPossibleValue);
+        FieldSettingsDto fieldSettingsDto2 = new FieldSettingsDto();
+        fieldSettingsDto2.setColumnName(activeColumnName);
+        fieldSettingsDto2.setPossibleValues(activePossibleValue);
+        FieldSettingsDto fieldSettingsDto3 = new FieldSettingsDto();
+        fieldSettingsDto3.setColumnName(ethnicityColumnName);
+        fieldSettingsDto3.setPossibleValues(ethnicityPossibleValue);
+
+        return Arrays.asList(fieldSettingsDto1, fieldSettingsDto2, fieldSettingsDto3);
+    }
+}


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/browse/DDP-5713

**Things have done:**

- Created Dao/Dto classes for `field_settings`.
- Created new `FieldSettings` class which encapsulates all business logic related to `field_settings`.
- Added method `addDefaultOptionsValueToData` in `NewParticipantData`, which adds default value options to new family member if this new family member does not have it already.
- Created unit tests for `FieldSettings`.