### PR TITLE
DDP-5934: GBF SHIPPED should trigger DSS DELIVERED event 

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/statics/DBConstants.java
+++ b/src/main/java/org/broadinstitute/dsm/statics/DBConstants.java
@@ -278,6 +278,7 @@ public class DBConstants {
     public static final String PARTICIPANT_STATUS_ENDPOINT = "participant_status_endpoint";
     public static final String ADD_FAMILY_MEMBER = "add_family_member";
     public static final String SHOW_GROUP_FIELDS = "show_group_fields";
+    public static final String GBF_SHIPPED_DSS_DELIVERED = "GBF_SHIPPED_DSS_DELIVERED";
 
     //user role
     public static final String MAILINGLIST_VIEW = "mailingList_view";

--- a/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/externalShipper/GBFRequestUtil.java
@@ -10,7 +10,9 @@ import org.broadinstitute.ddp.db.SimpleResult;
 import org.broadinstitute.ddp.util.Utility;
 import org.broadinstitute.dsm.DSMServer;
 import org.broadinstitute.dsm.db.DDPInstance;
+import org.broadinstitute.dsm.db.InstanceSettings;
 import org.broadinstitute.dsm.exception.ExternalShipperException;
+import org.broadinstitute.dsm.jobs.TestBostonUPSTrackingJob;
 import org.broadinstitute.dsm.model.*;
 import org.broadinstitute.dsm.model.gbf.*;
 import org.broadinstitute.dsm.statics.DBConstants;
@@ -201,7 +203,7 @@ public class GBFRequestUtil implements ExternalShipper {
     //  Status is as it sounds, a real-time status of the order progression through the GBF internal process
     // 'RECEIVED', 'PROCESSING', 'SHIPPED', 'DISTRIBUTION', 'FORMS PRINTED', 'CANCELLED', 'NOT FOUND', 'SHIPPED (SIMULATED)'
     // return the actual tube barcode for all tubes but only after the kit is shipped (around 7:00pm)
-    public void orderStatus(Connection conn, KitRequest kit) throws Exception {
+    public void orderStatus(Connection conn, KitRequest kit, int instanceId, boolean gbfShippedTriggerDSSDelivered) throws Exception {
         logger.info("checking status of " + kit.getExternalOrderNumber() + " for participant " + kit.getParticipantId());
         List<String> orderNumbers = new ArrayList<>();
         orderNumbers.addAll(Arrays.asList(new String[] { kit.getExternalOrderNumber() }));
@@ -232,8 +234,17 @@ public class GBFRequestUtil implements ExternalShipper {
                             !kit.getExternalOrderStatus().contains(SHIPPED))) {
                         if (kitDDPNotification != null) {
                             logger.info("Triggering DDP for shipped kit with external order number: " + kit.getExternalOrderNumber());
+                            if (gbfShippedTriggerDSSDelivered) {
+                                KitDDPNotification kitDeliveredNotification = KitDDPNotification.getKitDDPNotification(conn, TestBostonUPSTrackingJob.SQL_SELECT_KIT_FOR_NOTIFICATION_EXTERNAL_SHIPPER + TestBostonUPSTrackingJob.SELECT_BY_EXTERNAL_ORDER_NUMBER, new String[] {  TestBostonUPSTrackingJob.DELIVERED, String.valueOf(instanceId), kit.getDsmKitRequestId(), kit.getExternalOrderNumber() }, 1);//todo change this to the number of subkits but for now 2 for test boston works
+                                if (kitDeliveredNotification != null) {
+                                    logger.info("Triggering DDP for kit 'DELIVERED' with external order number: " + kit.getExternalOrderNumber());
+                                    EventUtil.triggerDDP(conn, kitDeliveredNotification);
+                                }
+                                else {
+                                    logger.error("delivered kitDDPNotification was null for " + kit.getExternalOrderNumber());
+                                }
+                            }
                             EventUtil.triggerDDP(conn, kitDDPNotification);
-
                         }
                         else {
                             logger.error("kitDDPNotification was null for " + kit.getExternalOrderNumber());
@@ -349,6 +360,7 @@ public class GBFRequestUtil implements ExternalShipper {
      * details from GBF
      */
     private void updateOrderStatusForPendingKitRequests(int instanceId, String query) {
+        boolean gbfShippedTriggerDSSDelivered = InstanceSettings.getInstanceSettings(instanceId).isGbfShippedTriggerDSSDelivered();
         final AtomicInteger numOrdersProcessed = new AtomicInteger();
         final Set<String> queriedOrderIds = new HashSet<>();
         SimpleResult results = inTransaction((conn) -> {
@@ -368,7 +380,7 @@ public class GBFRequestUtil implements ExternalShipper {
                                 // keep track of which request ids we've already asked about, since this
                                 // result set may show subkits with the same external order id
                                 if (!queriedOrderIds.contains(kitRequest.getExternalOrderNumber())) {
-                                    orderStatus(conn, kitRequest);
+                                    orderStatus(conn, kitRequest, instanceId, gbfShippedTriggerDSSDelivered);
                                     numOrdersProcessed.incrementAndGet();
                                     queriedOrderIds.add(kitRequest.getExternalOrderNumber());
                                 }

--- a/src/main/resources/liquibase/050-updateDB.xml
+++ b/src/main/resources/liquibase/050-updateDB.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="DDP-5934" author="simone" >
+        <addColumn tableName="instance_settings">
+            <column name="GBF_SHIPPED_DSS_DELIVERED" type="tinyint(1)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/master-changelog.xml
+++ b/src/main/resources/master-changelog.xml
@@ -41,7 +41,7 @@
     <include file="liquibase/036-updateDB.xml" relativeToChangelogFile="true"/>
     <include file="liquibase/037-updateDB.xml" relativeToChangelogFile="true"/>
     <include file="liquibase/038-updateDB.xml" relativeToChangelogFile="true"/>
-    <include file="liquibase/039-updateDB.xml" relativeToChangelogFile="true"/>
+<!--    <include file="liquibase/039-updateDB.xml" relativeToChangelogFile="true"/>-->
     <include file="liquibase/040-updateDB.xml" relativeToChangelogFile="true"/>
     <include file="liquibase/041-updateDB.xml" relativeToChangelogFile="true"/>
     <include file="liquibase/042-updateDB.xml" relativeToChangelogFile="true"/>


### PR DESCRIPTION
(per instance setting so that it an be easily reverted if study staff wants it changed back)

1) add a flag to the db instance_settings GBF_SHIPPED_DSS_DELIVERED
2) change `TestBostonUPSTrackingJob.shouldTriggerEventForKitOnItsWayToParticipant` to check for that flag if `GBF_SHIPPED_DSS_DELIVERED` is true return false
3) change `GBFRequestUtil.orderStatus` to check for the flag and if it is true trigger the ddp 
