### PR TITLE
Elastic export fix for samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ target
 npm-debug.log
 testem.log
 /typings
+checkstyle.xml
 
 # e2e
 /e2e

--- a/src/main/java/org/broadinstitute/dsm/db/dao/ddp/kitrequest/KitRequestDao.java
+++ b/src/main/java/org/broadinstitute/dsm/db/dao/ddp/kitrequest/KitRequestDao.java
@@ -19,7 +19,7 @@ public class KitRequestDao implements Dao<KitRequestDto> {
 
     public static final String SQL_SELECT_ES_SAMPLE =
             "SELECT " +
-            "dp.ddp_participant_id, " +
+            "kr.ddp_participant_id, " +
             "kr.ddp_kit_request_id, " +
             "kt.kit_type_name, " +
             "dk.kit_label, " +
@@ -32,9 +32,7 @@ public class KitRequestDao implements Dao<KitRequestDto> {
             "dk.easypost_shipment_date, " +
             "dk.receive_date " +
                     "FROM " +
-            "ddp_participant dp " +
-            "LEFT JOIN " +
-            "ddp_kit_request kr ON dp.ddp_participant_id = kr.ddp_participant_id " +
+            "ddp_kit_request kr "+
             "LEFT JOIN " +
             "ddp_kit dk ON dk.dsm_kit_request_id = kr.dsm_kit_request_id " +
             "LEFT JOIN " +
@@ -45,7 +43,7 @@ public class KitRequestDao implements Dao<KitRequestDto> {
             "LEFT JOIN " +
             "carrier_service cs ON (krs.carrier_service_to_id = cs.carrier_service_id)";
 
-    public static final String BY_INSTANCE_ID = " WHERE dp.ddp_instance_id = ?";
+    public static final String BY_INSTANCE_ID = " WHERE kr.ddp_instance_id = ?";
 
     public static final String SQL_GET_KIT_REQUEST_ID =
             "SELECT " +
@@ -152,9 +150,9 @@ public class KitRequestDao implements Dao<KitRequestDto> {
                                         ESSampleRs.getString(DBConstants.DSM_TRACKING_TO),
                                         ESSampleRs.getString(DBConstants.DSM_TRACKING_RETURN),
                                         ESSampleRs.getString(DBConstants.CARRIER),
-                                        SystemUtil.getDateFormatted(ESSampleRs.getLong(DBConstants.DSM_SCAN_DATE)),
-                                        SystemUtil.getDateFormatted(ESSampleRs.getLong(DBConstants.EASYPOST_SHIPMENT_DATE)),
-                                        SystemUtil.getDateFormatted(ESSampleRs.getLong(DBConstants.DSM_RECEIVE_DATE))
+                                        SystemUtil.getNullOrDateFormatted(ESSampleRs.getLong(DBConstants.DSM_SCAN_DATE)),
+                                        SystemUtil.getNullOrDateFormatted(ESSampleRs.getLong(DBConstants.EASYPOST_SHIPMENT_DATE)),
+                                        SystemUtil.getNullOrDateFormatted(ESSampleRs.getLong(DBConstants.DSM_RECEIVE_DATE))
                                 )
                         );
                     }

--- a/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
@@ -400,7 +400,7 @@ public class ElasticSearchUtil {
                     objectsMapES.put(objectType, objectList);
                 }
 
-                updateRequest(ddpParticipantId, index, objectsMapES);
+                //updateRequest(ddpParticipantId, index, objectsMapES);
                 logger.info("Updated " + objectType + " information for participant " + ddpParticipantId + " in ES for instance " + instance.getName());
             }
         } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
@@ -400,7 +400,7 @@ public class ElasticSearchUtil {
                     objectsMapES.put(objectType, objectList);
                 }
 
-                //updateRequest(ddpParticipantId, index, objectsMapES);
+                updateRequest(ddpParticipantId, index, objectsMapES);
                 logger.info("Updated " + objectType + " information for participant " + ddpParticipantId + " in ES for instance " + instance.getName());
             }
         } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
@@ -415,7 +415,7 @@ public class ElasticSearchUtil {
             for (Map<String, Object> object : objectList) {
                 if (id.toString().equals(object.get(idName).toString())) {
                     for (Map.Entry<String, Object> entry: nameValues.entrySet()) {
-                        if (entry.getKey() != idName && entry.getKey() != ESObjectConstants.DDP_PARTICIPANT_ID) {
+                        if (!entry.getKey().equals(idName) && !entry.getKey().equals(ESObjectConstants.DDP_PARTICIPANT_ID)) {
                             object.put(entry.getKey(), entry.getValue());
                         }
                     }
@@ -452,7 +452,7 @@ public class ElasticSearchUtil {
         Map<String, Object> newObjectMap = new HashMap<>();
         newObjectMap.put(idName, id);
         for (Map.Entry<String, Object> entry: nameValues.entrySet()) {
-            if (entry.getKey() != idName && entry.getKey() != ESObjectConstants.DDP_PARTICIPANT_ID) {
+            if (!entry.getKey().equals(idName) && !entry.getKey().equals(ESObjectConstants.DDP_PARTICIPANT_ID)) {
                 newObjectMap.put(entry.getKey(), entry.getValue());
             }
         }

--- a/src/main/java/org/broadinstitute/dsm/util/SystemUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/SystemUtil.java
@@ -76,6 +76,13 @@ public class SystemUtil {
         return sdf.format(date);
     }
 
+    public static String getNullOrDateFormatted(long inputDate) {
+        if (inputDate == 0) {
+            return null;
+        }
+        return getDateFormatted(inputDate);
+    }
+
     public static long getLongFromDateString(String dateString) {
         if (StringUtils.isNotBlank(dateString)) {
             return getLong(dateString, FULL_DATE);


### PR DESCRIPTION
Changed query for samples, so that we don't use ddp_participant anymore. Changed the bug when in cases when date for samples had value null, it was taking it as 0 and exported as January 1st, 1970, but now it exports null.