### PR TITLE
DDP-6269 | rgp family id to es dsm object

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/statics/ESObjectConstants.java
+++ b/src/main/java/org/broadinstitute/dsm/statics/ESObjectConstants.java
@@ -29,4 +29,8 @@ public class ESObjectConstants {
 
     //common
     public static final String DDP_PARTICIPANT_ID = "ddpParticipantId";
+
+    //dsm
+    public static final String DSM = "dsm";
+    public static final String FAMILY_ID = "familyId"; //needed for RGP so far
 }

--- a/src/test/java/org/broadinstitute/dsm/model/rgp/AutomaticProbandDataCreatorTest.java
+++ b/src/test/java/org/broadinstitute/dsm/model/rgp/AutomaticProbandDataCreatorTest.java
@@ -1,0 +1,40 @@
+package org.broadinstitute.dsm.model.rgp;
+
+import static org.broadinstitute.dsm.TestHelper.setupDB;
+import static org.junit.Assert.*;
+
+import java.util.Map;
+
+import org.broadinstitute.dsm.statics.ESObjectConstants;
+import org.broadinstitute.dsm.util.ElasticSearchUtil;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class AutomaticProbandDataCreatorTest {
+
+
+    @BeforeClass
+    public static void before() throws Exception {
+        setupDB();
+    }
+
+    @Test
+    public void insertFamilyIdToEs() {
+        int familyId = 999;
+        String participantId = "S3POBS0P9X0MB41FT1JZ";
+        String esIndex = "participants_structured.rgp.rgp";
+        new AutomaticProbandDataCreator().insertFamilyIdToDsmES(esIndex, participantId,
+                familyId);
+        int familyIdFromEs = 0;
+        try {
+            Map<String, Object> esObjectsMap = ElasticSearchUtil.getObjectsMap(esIndex, participantId, ESObjectConstants.DSM);
+            Map<String, Object> dsmObjectMap = (Map<String, Object>) esObjectsMap.get(ESObjectConstants.DSM);
+            familyIdFromEs = (Integer) dsmObjectMap.get(ESObjectConstants.FAMILY_ID);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        Assert.assertEquals(familyId, familyIdFromEs);
+    }
+
+}


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/browse/DDP-6269

**Things have done:**

- Added method `insertFamilyIdToDsmES` which adds `familyId` into participant's dsm object.