### PR TITLE
DDP-6433 | default email to proband and family members

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/model/elasticsearch/ESAddress.java
+++ b/src/main/java/org/broadinstitute/dsm/model/elasticsearch/ESAddress.java
@@ -1,0 +1,62 @@
+package org.broadinstitute.dsm.model.elasticsearch;
+
+import com.google.gson.annotations.SerializedName;
+
+public class ESAddress {
+
+    @SerializedName("street1")
+    private String street1;
+
+    @SerializedName("street2")
+    private String street2;
+
+    @SerializedName("city")
+    private String city;
+
+    @SerializedName("state")
+    private String state;
+
+    @SerializedName("zip")
+    private String zip;
+
+    @SerializedName("country")
+    private String country;
+
+    @SerializedName("phone")
+    private String phone;
+
+    @SerializedName("mailToName")
+    private String recipient;
+
+    public String getStreet1() {
+        return street1;
+    }
+
+    public String getStreet2() {
+        return street2;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public String getZip() {
+        return zip;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public String getRecipient() {
+        return recipient;
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/model/elasticsearch/ESProfile.java
+++ b/src/main/java/org/broadinstitute/dsm/model/elasticsearch/ESProfile.java
@@ -1,0 +1,22 @@
+package org.broadinstitute.dsm.model.elasticsearch;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import org.broadinstitute.dsm.statics.ESObjectConstants;
+
+@Data
+public class ESProfile {
+
+    @SerializedName(ESObjectConstants.FIRST_NAME)
+    private String firstName;
+
+    @SerializedName(ESObjectConstants.LAST_NAME)
+    private String lastName;
+
+    @SerializedName(ESObjectConstants.GUID)
+    private String participantGuid;
+
+    @SerializedName(ESObjectConstants.EMAIL)
+    private String email;
+
+}

--- a/src/main/java/org/broadinstitute/dsm/model/elasticsearch/ElasticSearch.java
+++ b/src/main/java/org/broadinstitute/dsm/model/elasticsearch/ElasticSearch.java
@@ -86,17 +86,17 @@ public class ElasticSearch {
     }
 
     public static class Builder {
-        private Optional<ESAddress> address;
-        private Optional<List<Object>> medicalProviders;
-        private Optional<List<Object>> invitations;
-        private Optional<List<Object>> activities;
-        private Optional<Long> statusTimeStamp;
-        private Optional<ESProfile> profile;
-        private Optional<List<Object>> files;
-        private Optional<List<Object>> proxies;
-        private Optional<List<Map<String, String>>> workflows;
-        private Optional<String> status;
-        private Optional<Map<String, Object>> dsm;
+        private Optional<ESAddress> address = Optional.empty();
+        private Optional<List<Object>> medicalProviders = Optional.empty();
+        private Optional<List<Object>> invitations = Optional.empty();
+        private Optional<List<Object>> activities = Optional.empty();
+        private Optional<Long> statusTimeStamp = Optional.empty();
+        private Optional<ESProfile> profile = Optional.empty();
+        private Optional<List<Object>> files = Optional.empty();
+        private Optional<List<Object>> proxies = Optional.empty();
+        private Optional<List<Map<String, String>>> workflows = Optional.empty();
+        private Optional<String> status = Optional.empty();
+        private Optional<Map<String, Object>> dsm = Optional.empty();
 
         public Builder() {}
 

--- a/src/main/java/org/broadinstitute/dsm/model/elasticsearch/ElasticSearch.java
+++ b/src/main/java/org/broadinstitute/dsm/model/elasticsearch/ElasticSearch.java
@@ -1,0 +1,163 @@
+package org.broadinstitute.dsm.model.elasticsearch;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import lombok.Data;
+
+@Data
+public class ElasticSearch {
+
+    private static final Gson GSON = new Gson();
+
+    private Optional<ESAddress> address;
+    private Optional<List<Object>> medicalProviders;
+    private Optional<List<Object>> invitations;
+    private Optional<List<Object>> activities;
+    private Optional<Long> statusTimeStamp;
+    private Optional<ESProfile> profile;
+    private Optional<List<Object>> files;
+    private Optional<List<Object>> proxies;
+    private Optional<List<Map<String, String>>> workflows;
+    private Optional<String> status;
+    private Optional<Map<String, Object>> dsm;
+
+    private ElasticSearch(Builder builder) {
+        this.address = builder.address;
+        this.medicalProviders = builder.medicalProviders;
+        this.invitations = builder.invitations;
+        this.activities = builder.activities;
+        this.statusTimeStamp = builder.statusTimeStamp;
+        this.profile = builder.profile;
+        this.files = builder.files;
+        this.workflows = builder.workflows;
+        this.status = builder.status;
+        this.dsm = builder.dsm;
+    }
+
+    public static ElasticSearch parseSourceMap(Map<String, Object> sourceMap) {
+        if (sourceMap == null) return new ElasticSearch.Builder().build();
+        Builder builder = new Builder();
+        for (Field field:ElasticSearch.class.getDeclaredFields()) {
+            switch (field.getName()) {
+                case "address":
+                    builder.withAddress(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), ESAddress.class));
+                    break;
+                case "medicalProviders":
+                    builder.withMedicalProviders(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), new TypeToken<List<Object>>() {}.getType()));
+                    break;
+                case "invitations":
+                    builder.withInvitations(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), new TypeToken<List<Object>>() {}.getType()));
+                    break;
+                case "activities":
+                    builder.withActivities(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), new TypeToken<List<Object>>() {}.getType()));
+                    break;
+                case "statusTimeStamp":
+                    builder.withStatusTimeStamp(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), Long.class));
+                    break;
+                case "profile":
+                    builder.withProfile(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), ESProfile.class));
+                    break;
+                case "files":
+                    builder.withFiles(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), new TypeToken<List<Object>>() {}.getType()));
+                    break;
+                case "proxies":
+                    builder.withProxies(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), new TypeToken<List<Object>>() {}.getType()));
+                    break;
+                case "workflows":
+                    builder.withWorkFlows(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), new TypeToken<List<Map<String, String>>>() {}.getType()));
+                    break;
+                case "status":
+                    builder.withStatus(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), String.class));
+                    break;
+                case "dsm":
+                    builder.withDsm(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), new TypeToken<Map<String, Object>>() {}.getType()));
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        return builder.build();
+    }
+
+    public static class Builder {
+        private Optional<ESAddress> address;
+        private Optional<List<Object>> medicalProviders;
+        private Optional<List<Object>> invitations;
+        private Optional<List<Object>> activities;
+        private Optional<Long> statusTimeStamp;
+        private Optional<ESProfile> profile;
+        private Optional<List<Object>> files;
+        private Optional<List<Object>> proxies;
+        private Optional<List<Map<String, String>>> workflows;
+        private Optional<String> status;
+        private Optional<Map<String, Object>> dsm;
+
+        public Builder() {}
+
+        public Builder withAddress(ESAddress esAddress) {
+            this.address = Optional.ofNullable(esAddress);
+            return this;
+        }
+
+        public Builder withMedicalProviders(List<Object> medicalProviders) {
+            this.medicalProviders = Optional.ofNullable(medicalProviders);
+            return this;
+        }
+
+        public Builder withInvitations(List<Object> invitations) {
+            this.invitations = Optional.ofNullable(invitations);
+            return this;
+        }
+
+        public Builder withActivities(List<Object> activities) {
+            this.activities = Optional.ofNullable(activities);
+            return this;
+        }
+
+        public Builder withStatusTimeStamp(Long statusTimeStamp) {
+            this.statusTimeStamp = Optional.ofNullable(statusTimeStamp);
+            return this;
+        }
+
+        public Builder withProfile(ESProfile profile) {
+            this.profile = Optional.ofNullable(profile);
+            return this;
+        }
+
+        public Builder withFiles(List<Object> files) {
+            this.files = Optional.ofNullable(files);
+            return this;
+        }
+
+        public Builder withProxies(List<Object> proxies) {
+            this.proxies = Optional.ofNullable(proxies);
+            return this;
+        }
+
+        public Builder withWorkFlows(List<Map<String, String>> workflows) {
+            this.workflows = Optional.ofNullable(workflows);
+            return this;
+        }
+
+        public Builder withStatus(String status) {
+            this.status = Optional.ofNullable(status);
+            return this;
+        }
+
+        public Builder withDsm(Map<String, Object> dsm) {
+            this.dsm = Optional.ofNullable(dsm);
+            return this;
+        }
+
+        public ElasticSearch build() {
+            return new ElasticSearch(this);
+        }
+    }
+
+}

--- a/src/main/java/org/broadinstitute/dsm/model/elasticsearch/ElasticSearch.java
+++ b/src/main/java/org/broadinstitute/dsm/model/elasticsearch/ElasticSearch.java
@@ -42,46 +42,45 @@ public class ElasticSearch {
     public static ElasticSearch parseSourceMap(Map<String, Object> sourceMap) {
         if (sourceMap == null) return new ElasticSearch.Builder().build();
         Builder builder = new Builder();
-        for (Field field:ElasticSearch.class.getDeclaredFields()) {
-            switch (field.getName()) {
+        for (Map.Entry<String, Object> entry : sourceMap.entrySet()) {
+            switch (entry.getKey()) {
                 case "address":
-                    builder.withAddress(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), ESAddress.class));
+                    builder.withAddress(GSON.fromJson(GSON.toJson(entry.getValue()), ESAddress.class));
                     break;
                 case "medicalProviders":
-                    builder.withMedicalProviders(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), new TypeToken<List<Object>>() {}.getType()));
+                    builder.withMedicalProviders(GSON.fromJson(GSON.toJson(entry.getValue()), new TypeToken<List<Object>>() {}.getType()));
                     break;
                 case "invitations":
-                    builder.withInvitations(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), new TypeToken<List<Object>>() {}.getType()));
+                    builder.withInvitations(GSON.fromJson(GSON.toJson(entry.getValue()), new TypeToken<List<Object>>() {}.getType()));
                     break;
                 case "activities":
-                    builder.withActivities(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), new TypeToken<List<Object>>() {}.getType()));
+                    builder.withActivities(GSON.fromJson(GSON.toJson(entry.getValue()), new TypeToken<List<Object>>() {}.getType()));
                     break;
                 case "statusTimeStamp":
-                    builder.withStatusTimeStamp(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), Long.class));
+                    builder.withStatusTimeStamp(GSON.fromJson(GSON.toJson(entry.getValue()), Long.class));
                     break;
                 case "profile":
-                    builder.withProfile(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), ESProfile.class));
+                    builder.withProfile(GSON.fromJson(GSON.toJson(entry.getValue()), ESProfile.class));
                     break;
                 case "files":
-                    builder.withFiles(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), new TypeToken<List<Object>>() {}.getType()));
+                    builder.withFiles(GSON.fromJson(GSON.toJson(entry.getValue()), new TypeToken<List<Object>>() {}.getType()));
                     break;
                 case "proxies":
-                    builder.withProxies(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), new TypeToken<List<Object>>() {}.getType()));
+                    builder.withProxies(GSON.fromJson(GSON.toJson(entry.getValue()), new TypeToken<List<Object>>() {}.getType()));
                     break;
                 case "workflows":
-                    builder.withWorkFlows(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), new TypeToken<List<Map<String, String>>>() {}.getType()));
+                    builder.withWorkFlows(GSON.fromJson(GSON.toJson(entry.getValue()), new TypeToken<List<Map<String, String>>>() {}.getType()));
                     break;
                 case "status":
-                    builder.withStatus(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), String.class));
+                    builder.withStatus(GSON.fromJson(GSON.toJson(entry.getValue()), String.class));
                     break;
                 case "dsm":
-                    builder.withDsm(GSON.fromJson(GSON.toJson(sourceMap.get(field.getName())), new TypeToken<Map<String, Object>>() {}.getType()));
+                    builder.withDsm(GSON.fromJson(GSON.toJson(entry.getValue()), new TypeToken<Map<String, Object>>() {}.getType()));
                     break;
                 default:
                     break;
             }
         }
-
         return builder.build();
     }
 

--- a/src/main/java/org/broadinstitute/dsm/model/participant/data/AddFamilyMemberPayload.java
+++ b/src/main/java/org/broadinstitute/dsm/model/participant/data/AddFamilyMemberPayload.java
@@ -9,16 +9,16 @@ import lombok.Setter;
 @Setter
 public class AddFamilyMemberPayload {
 
-    private String participantGuid;
+    private String participantId;
     private String realm;
     private FamilyMemberDetails data;
     private Integer userId;
     private Boolean copyProbandInfo;
     private int probandDataId;
 
-    public AddFamilyMemberPayload(String participantGuid, String realm, FamilyMemberDetails data, Integer userId,
+    public AddFamilyMemberPayload(String participantId, String realm, FamilyMemberDetails data, Integer userId,
                                   Boolean copyProbandInfo, int probandDataId) {
-        this.participantGuid = participantGuid;
+        this.participantId = participantId;
         this.realm = realm;
         this.data = data;
         this.userId = userId;
@@ -26,8 +26,8 @@ public class AddFamilyMemberPayload {
         this.probandDataId = probandDataId;
     }
 
-    public Optional<String> getParticipantGuid() {
-        return Optional.ofNullable(participantGuid);
+    public Optional<String> getParticipantId() {
+        return Optional.ofNullable(participantId);
     }
 
     public Optional<String> getRealm() {

--- a/src/main/java/org/broadinstitute/dsm/model/participant/data/FamilyMemberConstants.java
+++ b/src/main/java/org/broadinstitute/dsm/model/participant/data/FamilyMemberConstants.java
@@ -7,8 +7,8 @@ public class FamilyMemberConstants {
     public static final String MEMBER_TYPE = "MEMBER_TYPE";
     public static final String FAMILY_ID = "FAMILY_ID";
     public static final String COLLABORATOR_PARTICIPANT_ID = "COLLABORATOR_PARTICIPANT_ID";
-    public static final String PHONE = "PHONE";
-    public static final String EMAIL = "EMAIL";
+    public static final String PHONE = "DATSTAT_MOBILEPHONE";
+    public static final String EMAIL = "DATSTAT_ALTEMAIL";
     public static final String MEMBER_TYPE_SELF = "SELF";
 
     public static final int PROBAND_RELATIONSHIP_ID = 3;

--- a/src/main/java/org/broadinstitute/dsm/model/participant/data/NewParticipantData.java
+++ b/src/main/java/org/broadinstitute/dsm/model/participant/data/NewParticipantData.java
@@ -13,8 +13,12 @@ import com.google.gson.reflect.TypeToken;
 import lombok.Data;
 import lombok.NonNull;
 import org.broadinstitute.dsm.db.dao.Dao;
+import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
 import org.broadinstitute.dsm.db.dao.participant.data.ParticipantDataDao;
 import org.broadinstitute.dsm.db.dto.participant.data.ParticipantDataDto;
+import org.broadinstitute.dsm.model.elasticsearch.ESProfile;
+import org.broadinstitute.dsm.model.elasticsearch.ElasticSearch;
+import org.broadinstitute.dsm.util.ElasticSearchUtil;
 
 @Data
 public class NewParticipantData {
@@ -75,10 +79,26 @@ public class NewParticipantData {
         if (copyProbandInfo && probandDataId > 0) {
             Optional<NewParticipantData> maybeParticipantData = dataAccess.get(probandDataId).map(pd -> parseDto((ParticipantDataDto)pd));
             maybeParticipantData.ifPresent(p -> mergedData.putAll(p.getData()));
+        } else {
+            familyMemberPayload.getParticipantId().ifPresent(pId -> familyMemberData.setEmail(getParticipantEmailById(pId)));
         }
-        //after self/proband data has been put into mergedData, to replace self/proband's [FIRSTNAME, LASTNAME, MEMBER_TYPE...] values by new family member's data
-        mergedData.putAll(familyMemberData.toMap());
+        familyMemberData.toMap().forEach((k, v) -> mergedData.compute(k, (probandKey, probandVal) -> v != null ? v : probandVal));
         return mergedData;
+    }
+
+    private String getParticipantEmailById(String pId) {
+        dataAccess = new DDPInstanceDao();
+        StringBuilder email = new StringBuilder();
+        Optional<String> maybeEsParticipantIndex =
+                ((DDPInstanceDao) dataAccess).getEsParticipantIndexByInstanceId(ddpInstanceId);
+        maybeEsParticipantIndex.ifPresent(esParticipantIndex -> {
+            ElasticSearch participantESDataByParticipantId =
+                    ElasticSearchUtil.getParticipantESDataByParticipantId(esParticipantIndex, pId);
+            email.append(participantESDataByParticipantId.getProfile()
+                    .map(ESProfile::getEmail)
+                    .orElse(""));
+        });
+        return email.toString();
     }
 
     public void addDefaultOptionsValueToData(@NonNull Map<String, String> columnsWithDefaultOptions) {
@@ -95,6 +115,7 @@ public class NewParticipantData {
     }
 
     public void insertParticipantData(String userEmail) {
+        dataAccess = new ParticipantDataDao();
         ParticipantDataDto participantDataDto =
                 new ParticipantDataDto(this.ddpParticipantId, this.ddpInstanceId, this.fieldTypeId, new Gson().toJson(this.data),
                         System.currentTimeMillis(), userEmail);

--- a/src/main/java/org/broadinstitute/dsm/model/rgp/AutomaticProbandDataCreator.java
+++ b/src/main/java/org/broadinstitute/dsm/model/rgp/AutomaticProbandDataCreator.java
@@ -1,13 +1,10 @@
 package org.broadinstitute.dsm.model.rgp;
 
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import com.google.gson.Gson;
 import lombok.NonNull;
-import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.db.ParticipantData;
 import org.broadinstitute.dsm.db.dao.bookmark.BookmarkDao;
@@ -15,7 +12,6 @@ import org.broadinstitute.dsm.db.dao.fieldsettings.FieldSettingsDao;
 import org.broadinstitute.dsm.db.dao.participant.data.ParticipantDataDao;
 import org.broadinstitute.dsm.db.dto.bookmark.BookmarkDto;
 import org.broadinstitute.dsm.db.dto.fieldsettings.FieldSettingsDto;
-import org.broadinstitute.dsm.db.dto.participant.data.ParticipantDataDto;
 import org.broadinstitute.dsm.model.ddp.DDPActivityConstants;
 import org.broadinstitute.dsm.model.fieldsettings.FieldSettings;
 import org.broadinstitute.dsm.model.participant.data.FamilyMemberConstants;
@@ -104,8 +100,8 @@ public class AutomaticProbandDataCreator {
                     .findFirst();
             maybePhoneQuestionAnswer.ifPresent(ans -> mobilePhone.append(ans.get(DDPActivityConstants.ACTIVITY_QUESTION_ANSWER)));
         });
-        String firstName = (String) profile.get(ElasticSearchUtil.FIRST_NAME_FIELD);
-        String lastName = (String) profile.get(ElasticSearchUtil.LAST_NAME_FIELD);
+        String firstName = (String) profile.get(ESObjectConstants.FIRST_NAME);
+        String lastName = (String) profile.get(ESObjectConstants.LAST_NAME);
         String familyId = maybeBookmark
                 .map(bookmarkDto -> String.valueOf(bookmarkDto.getValue()))
                 .orElse((String) profile.get(ElasticSearchUtil.HRUID));

--- a/src/main/java/org/broadinstitute/dsm/route/familymember/AddFamilyMemberRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/familymember/AddFamilyMemberRoute.java
@@ -31,7 +31,7 @@ public class AddFamilyMemberRoute extends RequestHandler {
         Gson gson = new Gson();
         AddFamilyMemberPayload addFamilyMemberPayload = gson.fromJson(request.body(), AddFamilyMemberPayload.class);
 
-        String participantGuid = addFamilyMemberPayload.getParticipantGuid()
+        String participantGuid = addFamilyMemberPayload.getParticipantId()
                 .orElseThrow(() -> new NoSuchElementException("Participant Guid is not provided"));
 
         String realm =
@@ -60,12 +60,10 @@ public class AddFamilyMemberRoute extends RequestHandler {
         ParticipantDataDao participantDataDao = new ParticipantDataDao();
         try {
             NewParticipantData participantDataObject = new NewParticipantData(participantDataDao);
-            participantDataObject.setData(
-                    participantGuid,
-                    Integer.parseInt(ddpInstanceId),
-                    realm.toUpperCase() + NewParticipantData.FIELD_TYPE,
-                    participantDataObject.mergeParticipantData(addFamilyMemberPayload)
-                    );
+            participantDataObject.setDdpParticipantId(participantGuid);
+            participantDataObject.setDdpInstanceId(Integer.parseInt(ddpInstanceId));
+            participantDataObject.setFieldTypeId(realm.toUpperCase() + NewParticipantData.FIELD_TYPE);
+            participantDataObject.setData(participantDataObject.mergeParticipantData(addFamilyMemberPayload));
             participantDataObject.addDefaultOptionsValueToData(getDefaultOptions(Integer.parseInt(ddpInstanceId)));
             participantDataObject.insertParticipantData(User.getUser(uId).getEmail());
             logger.info("Family member for participant " + participantGuid + " successfully created");

--- a/src/main/java/org/broadinstitute/dsm/statics/ESObjectConstants.java
+++ b/src/main/java/org/broadinstitute/dsm/statics/ESObjectConstants.java
@@ -33,4 +33,10 @@ public class ESObjectConstants {
     //dsm
     public static final String DSM = "dsm";
     public static final String FAMILY_ID = "familyId"; //needed for RGP so far
+
+    //profile
+    public static final String EMAIL = "email";
+    public static final String FIRST_NAME = "firstName";
+    public static final String LAST_NAME = "lastName";
+    public static final String GUID = "guid";
 }

--- a/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import com.google.gson.annotations.SerializedName;
 import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
@@ -18,6 +17,9 @@ import org.broadinstitute.ddp.handlers.util.MedicalInfo;
 import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.model.Filter;
 import org.broadinstitute.dsm.model.ddp.DDPParticipant;
+import org.broadinstitute.dsm.model.elasticsearch.ESAddress;
+import org.broadinstitute.dsm.model.elasticsearch.ESProfile;
+import org.broadinstitute.dsm.model.elasticsearch.ElasticSearch;
 import org.broadinstitute.dsm.model.gbf.Address;
 import org.broadinstitute.dsm.statics.ApplicationConfigConstants;
 import org.broadinstitute.dsm.statics.DBConstants;
@@ -87,8 +89,6 @@ public class ElasticSearchUtil {
     public static final String STATUS = "status";
     public static final String PROFILE_CREATED_AT = "profile." + CREATED_AT;
     public static final String WORKFLOWS = "workflows";
-    public static final String FIRST_NAME_FIELD = "firstName";
-    public static final String LAST_NAME_FIELD = "lastName";
     public static final String EMAIL_FIELD = "email";
 
     public static RestHighLevelClient getClientForElasticsearchCloud(@NonNull String baseUrl,
@@ -202,6 +202,40 @@ public class ElasticSearchUtil {
             logger.info("Got " + esData.size() + " participants from ES for instance " + realm);
         }
         return esData;
+    }
+
+    public static ElasticSearch getParticipantESDataByParticipantId(@NonNull String index, @NonNull String participantId) {
+        ElasticSearch elasticSearch = new ElasticSearch.Builder().build();
+        try (RestHighLevelClient client = getClientForElasticsearchCloud(TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.ES_URL),
+                TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.ES_USERNAME), TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.ES_PASSWORD))) {
+            logger.info("Getting ES data for participant: " + participantId);
+            try {
+                elasticSearch = fetchESDataByParticipantId(index, participantId, client);
+            }
+            catch (Exception e) {
+                throw new RuntimeException("Couldn't get ES for participant: " + participantId + " from " + index, e);
+            }
+            logger.info("Got ES data for participant: " + participantId + " from " + index);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return elasticSearch;
+    }
+
+    public static ElasticSearch fetchESDataByParticipantId(String index, String participantId, RestHighLevelClient client) throws IOException {
+        String matchQueryName = ParticipantUtil.isGuid(participantId) ? "profile.guid" : "profile.legacyAltPid";
+        SearchRequest searchRequest = new SearchRequest(index);
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        SearchResponse response = null;
+        searchSourceBuilder.query(QueryBuilders.matchQuery(matchQueryName, participantId)).sort(PROFILE_CREATED_AT, SortOrder.ASC);
+        searchSourceBuilder.size(1);
+        searchSourceBuilder.from(0);
+        searchRequest.source(searchSourceBuilder);
+
+        response = client.search(searchRequest, RequestOptions.DEFAULT);
+        response.getHits();
+        return ElasticSearch.parseSourceMap(response.getHits().getTotalHits() > 0 ? response.getHits().getAt(0).getSourceAsMap() : null);
     }
 
     public static Map<String, Map<String, Object>> getDDPParticipantsFromES(@NonNull String realm, @NonNull String index) {
@@ -1154,87 +1188,4 @@ public class ElasticSearchUtil {
         }
     }
 
-    private static class ESProfile {
-
-        @SerializedName(FIRST_NAME_FIELD)
-        private String firstName;
-
-        @SerializedName(LAST_NAME_FIELD)
-        private String lastName;
-
-        @SerializedName("guid")
-        private String participantGuid;
-
-        public String getFirstName() {
-            return firstName;
-        }
-
-        public String getLastName() {
-            return lastName;
-        }
-
-        public String getParticipantGuid() {
-            return participantGuid;
-        }
-
-    }
-
-    private static class ESAddress {
-
-        @SerializedName("street1")
-        private String street1;
-
-        @SerializedName("street2")
-        private String street2;
-
-        @SerializedName("city")
-        private String city;
-
-        @SerializedName("state")
-        private String state;
-
-        @SerializedName("zip")
-        private String zip;
-
-        @SerializedName("country")
-        private String country;
-
-        @SerializedName("phone")
-        private String phone;
-
-        @SerializedName("mailToName")
-        private String recipient;
-
-        public String getStreet1() {
-            return street1;
-        }
-
-        public String getStreet2() {
-            return street2;
-        }
-
-        public String getCity() {
-            return city;
-        }
-
-        public String getState() {
-            return state;
-        }
-
-        public String getZip() {
-            return zip;
-        }
-
-        public String getCountry() {
-            return country;
-        }
-
-        public String getPhone() {
-            return phone;
-        }
-
-        public String getRecipient() {
-            return recipient;
-        }
-    }
 }

--- a/src/main/java/org/broadinstitute/dsm/util/ParticipantUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/ParticipantUtil.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsm.util;
 
 import lombok.NonNull;
+import org.apache.commons.lang3.StringUtils;
 
 public class ParticipantUtil {
 
@@ -9,5 +10,9 @@ public class ParticipantUtil {
     public static boolean isHruid(@NonNull String participantId) {
         final String hruidCheck = "^P\\w{5}$";
         return participantId.matches(hruidCheck);
+    }
+
+    public static boolean isGuid(@NonNull String participantId) {
+        return participantId.length() == 20;
     }
 }

--- a/src/main/java/org/broadinstitute/dsm/util/ParticipantUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/ParticipantUtil.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsm.util;
 
 import lombok.NonNull;
-import org.apache.commons.lang3.StringUtils;
 
 public class ParticipantUtil {
 

--- a/src/test/java/org/broadinstitute/dsm/ElasticSearchTest.java
+++ b/src/test/java/org/broadinstitute/dsm/ElasticSearchTest.java
@@ -3,6 +3,8 @@ package org.broadinstitute.dsm;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.lucene.search.join.ScoreMode;
 import org.broadinstitute.dsm.db.DDPInstance;
+import org.broadinstitute.dsm.model.elasticsearch.ESProfile;
+import org.broadinstitute.dsm.model.elasticsearch.ElasticSearch;
 import org.broadinstitute.dsm.statics.ESObjectConstants;
 import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.SystemUtil;
@@ -28,6 +30,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.*;
 
 public class ElasticSearchTest extends TestHelper {
@@ -394,6 +397,23 @@ public class ElasticSearchTest extends TestHelper {
     @Test
     public void searchPTByCompositeNotEmpty() throws Exception {
         notEmptyActivity("participants_structured.cmi.angio", "BIRTH_YEAR", "ANGIOABOUTYOU");
+    }
+
+    @Test
+    public void testSearchParticipantById() {
+        String pIdToFilter = "WUKIOQNKXJZGCAXCSYGB";
+        String fetchedPid = "";
+        try (RestHighLevelClient client = ElasticSearchUtil.getClientForElasticsearchCloud(cfg.getString("elasticSearch.url"), cfg.getString("elasticSearch.username"), cfg.getString("elasticSearch.password"))) {
+            ElasticSearch esObject =
+                    ElasticSearchUtil.fetchESDataByParticipantId("participants_structured.rgp.rgp", pIdToFilter, client);
+            fetchedPid = esObject.getProfile()
+                    .map(ESProfile::getParticipantGuid)
+                    .orElse("");
+        } catch (IOException e) {
+            Assert.fail();
+            e.printStackTrace();
+        }
+        Assert.assertEquals(pIdToFilter, fetchedPid);
     }
 
     public void notEmptyActivity(String index, String stableId, String activityCode) throws Exception {

--- a/src/test/java/org/broadinstitute/dsm/route/familymember/AddFamilyMemberRouteTest.java
+++ b/src/test/java/org/broadinstitute/dsm/route/familymember/AddFamilyMemberRouteTest.java
@@ -103,7 +103,7 @@ public class AddFamilyMemberRouteTest {
         String payload = payloadFactory(null, ddpInstanceDto.getInstanceName(), familyMemberData, user.getUserId());
         AddFamilyMemberPayload addFamilyMemberPayload = gson.fromJson(payload, AddFamilyMemberPayload.class);
         try {
-            addFamilyMemberPayload.getParticipantGuid().orElseThrow(() -> new NoSuchElementException("Participant Guid is not provided"));
+            addFamilyMemberPayload.getParticipantId().orElseThrow(() -> new NoSuchElementException("Participant Guid is not provided"));
         } catch (NoSuchElementException nsee) {
             Assert.assertEquals("Participant Guid is not provided", nsee.getMessage());
         }
@@ -148,7 +148,7 @@ public class AddFamilyMemberRouteTest {
         String payload = payloadFactory(participantId, ddpInstanceDto.getInstanceName(), probandData, user.getUserId());
         AddFamilyMemberPayload addFamilyMemberPayload = gson.fromJson(payload, AddFamilyMemberPayload.class);
         NewParticipantData participantData = new NewParticipantData(participantDataDao);
-        participantData.setData(addFamilyMemberPayload.getParticipantGuid().get(), ddpInstanceDto.getDdpInstanceId(),
+        participantData.setData(addFamilyMemberPayload.getParticipantId().get(), ddpInstanceDto.getDdpInstanceId(),
                 ddpInstanceDto.getInstanceName() + NewParticipantData.FIELD_TYPE, probandData);
         Assert.assertTrue(participantData.isRelationshipIdExists());
     }
@@ -160,7 +160,7 @@ public class AddFamilyMemberRouteTest {
         AddFamilyMemberPayload addFamilyMemberPayload = gson.fromJson(payload, AddFamilyMemberPayload.class);
         try {
             ParticipantDataDto participantDataDto = new ParticipantDataDto(
-                    addFamilyMemberPayload.getParticipantGuid().get(),
+                    addFamilyMemberPayload.getParticipantId().get(),
                     ddpInstanceDto.getDdpInstanceId(),
                     ddpInstanceDto.getInstanceName() + NewParticipantData.FIELD_TYPE,
                     gson.toJson(addFamilyMemberPayload.getData().get()),
@@ -184,7 +184,7 @@ public class AddFamilyMemberRouteTest {
         Map<String, String> copiedProbandToFamilyMember = new NewParticipantData(participantDataDao).mergeParticipantData(addFamilyMemberPayload);
         try {
             ParticipantDataDto participantDataDto = new ParticipantDataDto(
-                    addFamilyMemberPayload.getParticipantGuid().get(),
+                    addFamilyMemberPayload.getParticipantId().get(),
                     ddpInstanceDto.getDdpInstanceId(),
                     ddpInstanceDto.getInstanceName() + NewParticipantData.FIELD_TYPE,
                     gson.toJson(copiedProbandToFamilyMember),


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/browse/DDP-6433

**Things have done:**
- Introduced `ElasticSearch`(WIP | in class can be added many things and refactored type of instance fields, since it was first creation of this class did not examined all types which come from ES) class to handle ES data.
- Added method `getParticipantEmailById`, for default emails feature, to get participant email id.
- Added `getParticipantESDataByParticipantId` method which returns `ElasticSearch` object wtih ES data, which is filtered by participant id.
- Refactored code to fit newly Introduced `ElasticSearch` class.