### PR TITLE
DDP-6453 | default value for exited status

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/model/ParticipantWrapper.java
+++ b/src/main/java/org/broadinstitute/dsm/model/ParticipantWrapper.java
@@ -76,6 +76,7 @@ public class ParticipantWrapper {
         if (StringUtils.isBlank(instance.getParticipantIndexES())) {
             throw new RuntimeException("No participant index setup in ddp_instance table for " + instance.getName());
         }
+        DefaultValues defaultValues;
         if (filters == null) {
             Map<String, Map<String, Object>> participantESData = getESData(instance);
             Map<String, Participant> participants = Participant.getParticipants(instance.getName());
@@ -101,7 +102,8 @@ public class ParticipantWrapper {
 
             //if study is AT
             if ("atcp".equals(instance.getName())) {
-                participantData = DefaultValues.addDefaultValues(participantData, participantESData, instance, null);
+                defaultValues = new DefaultValues(participantData, participantESData, instance, null);
+                participantData = defaultValues.addDefaultValues();
             }
 
             List<String> baseList = new ArrayList<>(participantESData.keySet());
@@ -145,7 +147,9 @@ public class ParticipantWrapper {
 
                         //if study is AT
                         if ("atcp".equals(instance.getName())) {
-                            participantData = DefaultValues.addDefaultValues(participantData, participantESData, instance, filters.get(source));
+                            defaultValues =
+                                    new DefaultValues(participantData, participantESData, instance, filters.get(source));
+                            participantData = defaultValues.addDefaultValues();
                         }
                     }
                     else if (DBConstants.DDP_ABSTRACTION_ALIAS.equals(source)) {
@@ -206,7 +210,8 @@ public class ParticipantWrapper {
 
                 //if study is AT
                 if ("atcp".equals(instance.getName())) {
-                    participantData = DefaultValues.addDefaultValues(participantData, participantESData, instance, null);
+                    defaultValues = new DefaultValues(participantData, participantESData, instance, null);
+                    participantData = defaultValues.addDefaultValues();
                 }
             }
             if (abstractionActivities == null) {

--- a/src/main/java/org/broadinstitute/dsm/model/at/DefaultValues.java
+++ b/src/main/java/org/broadinstitute/dsm/model/at/DefaultValues.java
@@ -1,11 +1,16 @@
 package org.broadinstitute.dsm.model.at;
 
+import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.db.ParticipantData;
+import org.broadinstitute.dsm.db.dao.Dao;
 import org.broadinstitute.dsm.db.dao.ddp.participant.ParticipantDataDao;
+import org.broadinstitute.dsm.db.dao.fieldsettings.FieldSettingsDao;
+import org.broadinstitute.dsm.db.dto.fieldsettings.FieldSettingsDto;
+import org.broadinstitute.dsm.model.fieldsettings.FieldSettings;
 import org.broadinstitute.dsm.model.participant.data.NewParticipantData;
 import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.slf4j.Logger;
@@ -14,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class DefaultValues {
 
@@ -25,32 +31,51 @@ public class DefaultValues {
     private static final String REGISTRATION_TYPE = "REGISTRATION_TYPE";
     public static final String REGISTRATION_TYPE_SELF = "self";
     public static final String REGISTRATION_TYPE_DEPENDENT = "dependent";
+    public static final String EXITSTATUS = "EXITSTATUS";
 
-    public static Map<String, List<ParticipantData>> addDefaultValues(Map<String, List<ParticipantData>> participantData,
-                                        Map<String, Map<String, Object>> participantESData, @NonNull DDPInstance instance, String queryAddition) {
+    private static final Gson GSON = new Gson();
+    public static final String AT_PARTICIPANT_EXIT = "AT_PARTICIPANT_EXIT";
+    private Dao dataAccess;
+
+    private Map<String, List<ParticipantData>> participantData;
+    private Map<String, Map<String, Object>> participantESData;
+    private DDPInstance instance;
+    private String queryAddition;
+
+    public DefaultValues(Map<String, List<ParticipantData>> participantData,
+                         Map<String, Map<String, Object>> participantESData, @NonNull DDPInstance instance, String queryAddition) {
+        this.participantData = participantData;
+        this.participantESData = participantESData;
+        this.instance = instance;
+        this.queryAddition = queryAddition;
+    }
+
+    public Map<String, List<ParticipantData>> addDefaultValues() {
         if (participantESData == null) {
             logger.warn("Could not update default values, participant ES data is null");
             return participantData;
         }
         boolean addedNewParticipantData = false;
-        ParticipantDataDao participantDataDao = new ParticipantDataDao();
         for (Map.Entry<String, Map<String, Object>> entry: participantESData.entrySet()) {
             String ddpParticipantId = entry.getKey();
             List<ParticipantData> participantDataList = participantData.get(ddpParticipantId);
-            //only needed for new signups - migrated pts already have the values needed
             if (participantDataList == null) continue;
 
-            if (hasParticipantDataGenomicId(participantDataList)) continue;
-
-            if (isSelfOrDependentParticipant(participantDataList)) {
+            if (!hasParticipantDataGenomicId(participantDataList) && isSelfOrDependentParticipant(participantDataList)) {
                 Map<String, Object> esParticipantData = entry.getValue();
                 Map<String, Object> profile = (Map<String, Object>) esParticipantData.get(ElasticSearchUtil.PROFILE);
                 String hruid = (String) profile.get(ElasticSearchUtil.HRUID);
-
                 addedNewParticipantData = getParticipantGenomicFieldData(participantDataList)
-                        .map(pData -> updateGenomicIdForParticipant(instance, participantDataDao, ddpParticipantId, hruid, pData))
-                        .orElseGet(() -> insertGenomicIdForParticipant(instance, participantDataDao, ddpParticipantId, hruid));
+                        .map(pData -> insertGenomicIdIfNotExistsInData(ddpParticipantId, hruid, pData))
+                        .orElseGet(() -> insertGenomicIdForParticipant(ddpParticipantId, hruid));
             }
+
+            if (!hasExitedStatusDefaultValue(participantDataList) && isSelfOrDependentParticipant(participantDataList)) {
+                addedNewParticipantData = getParticipantExitFieldData(participantDataList)
+                        .map(pData -> insertExitStatusIfNotExistsInData(ddpParticipantId, pData))
+                        .orElseGet(() -> insertExitStatusForParticipant(ddpParticipantId));
+            }
+
         }
         if (addedNewParticipantData) {
             //participant data was added, getting new list of data
@@ -64,51 +89,109 @@ public class DefaultValues {
         return participantData;
     }
 
-    private static boolean updateGenomicIdForParticipant(DDPInstance instance, ParticipantDataDao participantDataDao, String ddpParticipantId, String hruid,
-                                       ParticipantData pData) {
-        if (StringUtils.isBlank(hruid)) return false;
-        NewParticipantData newParticipantData = new NewParticipantData(participantDataDao);
-        Map<String, String> dataMap = new Gson().fromJson(pData.getData(), Map.class);
-        dataMap.put(GENOME_STUDY_CPT_ID, PREFIX.concat(hruid));
-        newParticipantData.setData(ddpParticipantId, Integer.parseInt(instance.getDdpInstanceId()), pData.getFieldTypeId(), dataMap);
-        return newParticipantData.updateParticipantData(Integer.parseInt(pData.getDataId()), "SYSTEM");
-    }
-
-    private static boolean insertGenomicIdForParticipant(DDPInstance instance, ParticipantDataDao participantDataDao, String ddpParticipantId, String hruid) {
-        if (StringUtils.isBlank(hruid)) return false;
-        NewParticipantData newParticipantData = new NewParticipantData(participantDataDao);
-        Map<String, String> dataMap = Map.of(GENOME_STUDY_CPT_ID, PREFIX.concat(hruid));
-        newParticipantData.setData(ddpParticipantId, Integer.parseInt(instance.getDdpInstanceId()),
-                FIELD_TYPE_ID, dataMap);
-        newParticipantData.insertParticipantData("SYSTEM");
-        logger.info(GENOME_STUDY_CPT_ID + " was created for participant with id: " + ddpParticipantId + " at " + FIELD_TYPE_ID);
-        return true;
-    }
-
-    private static boolean isSelfOrDependentParticipant(List<ParticipantData> participantDataList) {
-        if (participantDataList.isEmpty()) return false;
-        return participantDataList.stream()
-                .anyMatch(pData -> {
-                    Map<String, String> data = new Gson().fromJson(pData.getData(), Map.class);
-                    return data.containsKey(REGISTRATION_TYPE) &&
-                            (REGISTRATION_TYPE_SELF.equalsIgnoreCase(data.get(REGISTRATION_TYPE))
-                            || REGISTRATION_TYPE_DEPENDENT.equalsIgnoreCase(data.get(REGISTRATION_TYPE)));
-                });
-    }
-
-    private static boolean hasParticipantDataGenomicId(List<ParticipantData> participantDataList) {
+    private boolean hasParticipantDataGenomicId(List<ParticipantData> participantDataList) {
         if (participantDataList.isEmpty()) return false;
         return participantDataList.stream()
                 .anyMatch(participantData -> {
-                    Map<String, String> data = new Gson().fromJson(participantData.getData(), Map.class);
+                    Map<String, String> data = GSON.fromJson(participantData.getData(), Map.class);
                     return data.containsKey(GENOME_STUDY_CPT_ID) && StringUtils.isNotBlank(data.get(GENOME_STUDY_CPT_ID));
                 });
     }
 
-    private static Optional<ParticipantData> getParticipantGenomicFieldData(List<ParticipantData> participantDataList) {
+    private boolean isSelfOrDependentParticipant(List<ParticipantData> participantDataList) {
+        if (participantDataList.isEmpty()) return false;
+        return participantDataList.stream()
+                .anyMatch(pData -> {
+                    Map<String, String> data = GSON.fromJson(pData.getData(), Map.class);
+                    return data.containsKey(REGISTRATION_TYPE) &&
+                            (REGISTRATION_TYPE_SELF.equalsIgnoreCase(data.get(REGISTRATION_TYPE))
+                                    || REGISTRATION_TYPE_DEPENDENT.equalsIgnoreCase(data.get(REGISTRATION_TYPE)));
+                });
+    }
+
+    private boolean hasExitedStatusDefaultValue(List<ParticipantData> participantDataList) {
+        if (participantDataList.isEmpty()) return false;
+        return participantDataList.stream()
+                .anyMatch(participantData -> {
+                    Map<String, String> data = GSON.fromJson(participantData.getData(), new TypeToken<Map<String, String>>() {}.getType());
+                    return AT_PARTICIPANT_EXIT.equals(participantData.getFieldTypeId()) && (data.containsKey(EXITSTATUS) && StringUtils.isNotBlank(data.get(EXITSTATUS)));
+                });
+    }
+
+    private Optional<ParticipantData> getParticipantGenomicFieldData(List<ParticipantData> participantDataList) {
         if (participantDataList.isEmpty()) return Optional.empty();
         return participantDataList.stream()
                 .filter(participantData -> FIELD_TYPE_ID.equals(participantData.getFieldTypeId()))
                 .findFirst();
     }
- }
+
+    private boolean insertGenomicIdIfNotExistsInData(String ddpParticipantId, String hruid,
+                                                     ParticipantData pData) {
+        if (StringUtils.isBlank(hruid)) return false;
+        Map<String, String> dataMap = GSON.fromJson(pData.getData(), new TypeToken<Map<String, String>>() {}.getType());
+        if (dataMap.containsKey(GENOME_STUDY_CPT_ID)) return false;
+        dataMap.put(GENOME_STUDY_CPT_ID, PREFIX.concat(hruid));
+        return updateParticipantData(ddpParticipantId, pData, dataMap);
+    }
+
+    private boolean insertGenomicIdForParticipant(String ddpParticipantId, String hruid) {
+        if (StringUtils.isBlank(hruid)) return false;
+        return insertParticipantData(Map.of(GENOME_STUDY_CPT_ID, PREFIX.concat(hruid)), ddpParticipantId, FIELD_TYPE_ID);
+    }
+
+    private Optional<ParticipantData> getParticipantExitFieldData(List<ParticipantData> participantDataList) {
+        if (participantDataList.isEmpty()) return Optional.empty();
+        return participantDataList.stream()
+                .filter(participantData -> AT_PARTICIPANT_EXIT.equals(participantData.getFieldTypeId()))
+                .findFirst();
+    }
+
+    private boolean insertExitStatusIfNotExistsInData(String ddpParticipantId, ParticipantData pData) {
+        Map<String, String> dataMap = GSON.fromJson(pData.getData(), new TypeToken<Map<String, String>>() {}.getType());
+        if (dataMap.containsKey(EXITSTATUS)) return false;
+        dataMap.put(EXITSTATUS, getDefaultExitStatus());
+        return updateParticipantData(ddpParticipantId, pData, dataMap);
+    }
+
+    private boolean insertExitStatusForParticipant(String ddpParticipantId) {
+        String datstatExitReasonDefaultOption = getDefaultExitStatus();
+        return insertParticipantData(Map.of(EXITSTATUS, datstatExitReasonDefaultOption), ddpParticipantId, AT_PARTICIPANT_EXIT);
+    }
+
+    private boolean updateParticipantData(String ddpParticipantId, ParticipantData pData, Map<String, String> dataMap) {
+        this.setDataAccess(new ParticipantDataDao());
+        NewParticipantData newParticipantData = new NewParticipantData(dataAccess);
+        newParticipantData.setData(ddpParticipantId, Integer.parseInt(instance.getDdpInstanceId()), pData.getFieldTypeId(), dataMap);
+        return newParticipantData.updateParticipantData(Integer.parseInt(pData.getDataId()), "SYSTEM");
+    }
+
+    private boolean insertParticipantData(Map<String, String> data, String ddpParticipantId, String fieldTypeId) {
+        this.setDataAccess(new ParticipantDataDao());
+        NewParticipantData newParticipantData = new NewParticipantData(dataAccess);
+        newParticipantData.setData(ddpParticipantId, Integer.parseInt(instance.getDdpInstanceId()),
+                fieldTypeId, data);
+        try {
+            newParticipantData.insertParticipantData("SYSTEM");
+            logger.info("values: " + data.keySet().stream().collect(Collectors.joining(", ", "[", "]")) + " were created for participant with id: " + ddpParticipantId + " at " + FIELD_TYPE_ID);
+            return true;
+        } catch (RuntimeException re) {
+            return false;
+        }
+    }
+
+    private String getDefaultExitStatus() {
+        this.setDataAccess(FieldSettingsDao.of());
+        Optional<FieldSettingsDto> fieldSettingByColumnNameAndInstanceId = ((FieldSettingsDao) dataAccess)
+                .getFieldSettingByColumnNameAndInstanceId(Integer.parseInt(instance.getDdpInstanceId()), EXITSTATUS);
+        return fieldSettingByColumnNameAndInstanceId.
+                map(fieldSettingsDto -> {
+                    FieldSettings fieldSettings = new FieldSettings();
+                    return fieldSettings.getDefaultOptionValue(fieldSettingsDto.getPossibleValues());
+                })
+                .orElse("");
+    }
+
+    private void setDataAccess(Dao dao) {
+        this.dataAccess = dao;
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/model/fieldsettings/FieldSettings.java
+++ b/src/main/java/org/broadinstitute/dsm/model/fieldsettings/FieldSettings.java
@@ -21,7 +21,7 @@ public class FieldSettings {
         Map<String, String> defaultOptions = new HashMap<>();
         for (FieldSettingsDto fieldSettingDto: fieldSettingsDtos) {
             if (isDefaultOption(fieldSettingDto.getPossibleValues())) {
-                defaultOptions.put(fieldSettingDto.getColumnName(), getDefaultOption(fieldSettingDto.getPossibleValues()));
+                defaultOptions.put(fieldSettingDto.getColumnName(), getDefaultOptionValue(fieldSettingDto.getPossibleValues()));
             }
         }
         return defaultOptions;
@@ -31,13 +31,13 @@ public class FieldSettings {
         Map<String, String> defaultOptionsFileredByElasticExportWorkflow = new HashMap<>();
         for (FieldSettingsDto fieldSettingsDto: fieldSettingsDtos) {
             if (isDefaultOption(fieldSettingsDto.getPossibleValues()) && isElasticExportWorkflowType(fieldSettingsDto.getActions())) {
-                defaultOptionsFileredByElasticExportWorkflow.put(fieldSettingsDto.getColumnName(), getDefaultOption(fieldSettingsDto.getPossibleValues()));
+                defaultOptionsFileredByElasticExportWorkflow.put(fieldSettingsDto.getColumnName(), getDefaultOptionValue(fieldSettingsDto.getPossibleValues()));
             }
         }
         return defaultOptionsFileredByElasticExportWorkflow;
     }
 
-    String getDefaultOption(String possibleValuesJson) {
+    public String getDefaultOptionValue(String possibleValuesJson) {
         List<Map<String, Object>> possibleValues = new Gson().fromJson(possibleValuesJson, List.class);
 
         return (String) possibleValues.stream()

--- a/src/main/resources/liquibase/DDP-6451_at-genomic-id-counter.xml
+++ b/src/main/resources/liquibase/DDP-6451_at-genomic-id-counter.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="at-genomic-id-counter" author="gmakhara" >
+        <insert tableName="bookmark">
+            <column name="value" type="BIGINT" value="715"/>
+            <column name="instance" value="at_genomic_id"/>
+        </insert>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/master-changelog.xml
+++ b/src/main/resources/master-changelog.xml
@@ -57,4 +57,5 @@
 <!--    <include file="liquibase/DDP-4702_AT-form.xml" relativeToChangelogFile="true"/>-->
 <!--    <include file="liquibase/DDP-5782_RGP-form.xml" relativeToChangelogFile="true"/>-->
     <include file="liquibase/DDP-6426_at-status-possible-values.xml" relativeToChangelogFile="true"/>
+    <include file="liquibase/DDP-6451_at-genomic-id-counter.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/test/java/org/broadinstitute/dsm/model/fieldsettings/FieldSettingsTest.java
+++ b/src/test/java/org/broadinstitute/dsm/model/fieldsettings/FieldSettingsTest.java
@@ -28,7 +28,7 @@ public class FieldSettingsTest {
 
     @Test
     public void testGetDefaultOption() {
-        String defaultOption = fieldSettings.getDefaultOption(acceptanceStatusPossibleValue);
+        String defaultOption = fieldSettings.getDefaultOptionValue(acceptanceStatusPossibleValue);
         Assert.assertEquals("ACCEPTED", defaultOption);
     }
 


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/browse/DDP-6453
Ticket: https://broadinstitute.atlassian.net/browse/DDP-6451 (genomic id part)

**Things have done:**
- Added script to add default exit status(`hasExitedStatusDefaultValue`, `getParticipantExitFieldData`, `insertExitStatusIfNotExistsInData`, `insertExitStatusForParticipant`).
- Changed `DefaultValues` class to OOP to have more flexibility and cleaner code.
- Introduced dependency injection principle using injection by setter `setDataAccess` method for interactions with DB.
- Refactored methods to have each of them single responsibility.