### PR TITLE
DDP-6467 | hotfix for proxy data

### DIFF
--- a/src/test/java/org/broadinstitute/dsm/ElasticSearchTest.java
+++ b/src/test/java/org/broadinstitute/dsm/ElasticSearchTest.java
@@ -55,7 +55,7 @@ public class ElasticSearchTest extends TestHelper {
                 searchRequest.source(searchSourceBuilder);
 
                 response = client.search(searchRequest, RequestOptions.DEFAULT);
-                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm");
+                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm", "participants_structured.rgp.rgp");
                 i++;
             }
             Assert.assertNotEquals(0, esData.size());
@@ -125,7 +125,7 @@ public class ElasticSearchTest extends TestHelper {
                 searchRequest.source(searchSourceBuilder);
 
                 response = client.search(searchRequest, RequestOptions.DEFAULT);
-                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm");
+                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm", "users.cmi.cmi-osteo");
                 i++;
             }
             Assert.assertNotEquals(0, esData.size());
@@ -149,7 +149,7 @@ public class ElasticSearchTest extends TestHelper {
                 searchRequest.source(searchSourceBuilder);
 
                 response = client.search(searchRequest, RequestOptions.DEFAULT);
-                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm");
+                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm", "participants_structured.cmi.cmi-osteo");
                 i++;
             }
             Assert.assertNotEquals(0, esData.size());
@@ -191,7 +191,7 @@ public class ElasticSearchTest extends TestHelper {
                 searchRequest.source(searchSourceBuilder);
 
                 response = client.search(searchRequest, RequestOptions.DEFAULT);
-                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm");
+                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm", index);
                 i++;
             }
             Assert.assertNotEquals(0, esData.size());
@@ -272,7 +272,7 @@ public class ElasticSearchTest extends TestHelper {
                 searchRequest.source(searchSourceBuilder);
 
                 response = client.search(searchRequest, RequestOptions.DEFAULT);
-                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm");
+                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm", index);
                 i++;
             }
             Assert.assertNotEquals(0, esData.size());
@@ -323,7 +323,7 @@ public class ElasticSearchTest extends TestHelper {
                 searchRequest.source(searchSourceBuilder);
 
                 response = client.search(searchRequest, RequestOptions.DEFAULT);
-                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm");
+                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm", index);
                 i++;
             }
             Assert.assertNotEquals(0, esData.size());
@@ -351,7 +351,7 @@ public class ElasticSearchTest extends TestHelper {
                 searchRequest.source(searchSourceBuilder);
 
                 response = client.search(searchRequest, RequestOptions.DEFAULT);
-                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm");
+                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm", "participants_structured.cmi.cmi-brain");
                 i++;
             }
             Assert.assertNotEquals(0, esData.size());
@@ -379,7 +379,7 @@ public class ElasticSearchTest extends TestHelper {
                 searchRequest.source(searchSourceBuilder);
 
                 response = client.search(searchRequest, RequestOptions.DEFAULT);
-                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm");
+                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm", "participants_structured.cmi.cmi-brain");
                 i++;
             }
             Assert.assertNotEquals(0, esData.size());
@@ -428,7 +428,7 @@ public class ElasticSearchTest extends TestHelper {
                 searchRequest.source(searchSourceBuilder);
 
                 response = client.search(searchRequest, RequestOptions.DEFAULT);
-                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm");
+                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm", index);
                 i++;
             }
             Assert.assertNotEquals(0, esData.size());
@@ -458,7 +458,7 @@ public class ElasticSearchTest extends TestHelper {
                 searchRequest.source(searchSourceBuilder);
 
                 response = client.search(searchRequest, RequestOptions.DEFAULT);
-                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm");
+                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm", "participants_structured.cmi.cmi-brain");
                 i++;
             }
             Assert.assertNotEquals(0, esData.size());
@@ -492,7 +492,7 @@ public class ElasticSearchTest extends TestHelper {
                 searchRequest.source(searchSourceBuilder);
 
                 response = client.search(searchRequest, RequestOptions.DEFAULT);
-                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm");
+                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm", "participants_structured.cmi.cmi-brain");
                 i++;
             }
             Assert.assertNotEquals(0, esData.size());
@@ -521,7 +521,7 @@ public class ElasticSearchTest extends TestHelper {
                 searchRequest.source(searchSourceBuilder);
 
                 response = client.search(searchRequest, RequestOptions.DEFAULT);
-                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm");
+                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm", "participants_structured.cmi.cmi-osteo");
                 i++;
             }
             Assert.assertNotEquals(0, esData.size());
@@ -546,7 +546,7 @@ public class ElasticSearchTest extends TestHelper {
                 searchRequest.source(searchSourceBuilder);
 
                 response = client.search(searchRequest, RequestOptions.DEFAULT);
-                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm");
+                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm", "participants_structured.cmi.cmi-osteo");
                 i++;
             }
             Assert.assertNotEquals(0, esData.size());
@@ -577,7 +577,7 @@ public class ElasticSearchTest extends TestHelper {
                 searchRequest.source(searchSourceBuilder);
 
                 response = client.search(searchRequest, RequestOptions.DEFAULT);
-                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm");
+                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm", "participants_structured.cmi.cmi-osteo");
                 i++;
             }
             Assert.assertNotEquals(0, esData.size());
@@ -622,7 +622,7 @@ public class ElasticSearchTest extends TestHelper {
                 searchRequest.source(searchSourceBuilder);
 
                 response = client.search(searchRequest, RequestOptions.DEFAULT);
-                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm");
+                ElasticSearchUtil.addingParticipantStructuredHits(response, esData, "realm", index);
                 i++;
             }
             Assert.assertNotEquals(0, esData.size());


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/browse/DDP-6467

**Things have done:**
- Added utility method which determines whether ES index is `participant_structured` or `users`.
- Added `index` as an argument to method which is responsible to create map from ES data, if index is `users` it will create map with `guid` as key, otherwise it will do the same job as it was doing before(will use legacy alt pid as key if exists).