### PR TITLE
DDP-6473 | Get guids of altpids from ES and update with those guids

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/export/ExportToES.java
+++ b/src/main/java/org/broadinstitute/dsm/export/ExportToES.java
@@ -44,8 +44,6 @@ public class ExportToES {
     public static final String FAMILY_ID = "FAMILY_ID";
     public static final String RGP_PARTICIPANTS = "RGP_PARTICIPANTS";
 
-    private Dao dataAccess;
-
     public static class ExportPayload {
         private String index;
         private String study;
@@ -138,7 +136,7 @@ public class ExportToES {
                 continue;
             }
             String ddpParticipantId = participantData.getDdpParticipantId();
-            if (ddpParticipantId.length() > 20) {
+            if (!ParticipantUtil.isGuid(ddpParticipantId)) {
                 ddpParticipantId = getGuidIfWeHaveAltpid(ddpParticipantId, maybeEsParticipantIndex);
             }
             if ("".equals(ddpParticipantId)) {

--- a/src/main/java/org/broadinstitute/dsm/export/ExportToES.java
+++ b/src/main/java/org/broadinstitute/dsm/export/ExportToES.java
@@ -3,7 +3,6 @@ package org.broadinstitute.dsm.export;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import org.broadinstitute.dsm.db.DDPInstance;
-import org.broadinstitute.dsm.db.dao.Dao;
 import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
 import org.broadinstitute.dsm.db.dao.ddp.kitrequest.KitRequestDao;
 import org.broadinstitute.dsm.db.dao.ddp.medical.records.ESMedicalRecordsDao;

--- a/src/main/java/org/broadinstitute/dsm/export/ExportToES.java
+++ b/src/main/java/org/broadinstitute/dsm/export/ExportToES.java
@@ -3,18 +3,21 @@ package org.broadinstitute.dsm.export;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import org.broadinstitute.dsm.db.DDPInstance;
+import org.broadinstitute.dsm.db.dao.Dao;
 import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
 import org.broadinstitute.dsm.db.dao.ddp.kitrequest.KitRequestDao;
 import org.broadinstitute.dsm.db.dao.ddp.medical.records.ESMedicalRecordsDao;
+import org.broadinstitute.dsm.db.dao.ddp.participant.ParticipantDataDao;
 import org.broadinstitute.dsm.db.dao.ddp.tissue.ESTissueRecordsDao;
 import org.broadinstitute.dsm.db.dao.fieldsettings.FieldSettingsDao;
-import org.broadinstitute.dsm.db.dao.ddp.participant.ParticipantDataDao;
 import org.broadinstitute.dsm.db.dto.ddp.kitrequest.ESSamplesDto;
 import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantDataDto;
+import org.broadinstitute.dsm.db.dto.ddp.tissue.ESTissueRecordsDto;
 import org.broadinstitute.dsm.db.dto.fieldsettings.FieldSettingsDto;
 import org.broadinstitute.dsm.db.dto.medical.records.ESMedicalRecordsDto;
-import org.broadinstitute.dsm.db.dto.ddp.tissue.ESTissueRecordsDto;
 import org.broadinstitute.dsm.model.Value;
+import org.broadinstitute.dsm.model.elasticsearch.ESProfile;
+import org.broadinstitute.dsm.model.elasticsearch.ElasticSearch;
 import org.broadinstitute.dsm.model.participant.data.FamilyMemberConstants;
 import org.broadinstitute.dsm.statics.ESObjectConstants;
 import org.broadinstitute.dsm.util.ElasticSearchUtil;
@@ -25,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class ExportToES {
@@ -39,6 +43,8 @@ public class ExportToES {
     private static final ObjectMapper oMapper = new ObjectMapper();
     public static final String FAMILY_ID = "FAMILY_ID";
     public static final String RGP_PARTICIPANTS = "RGP_PARTICIPANTS";
+
+    private Dao dataAccess;
 
     public static class ExportPayload {
         private String index;
@@ -124,9 +130,18 @@ public class ExportToES {
 
     public static void checkWorkflowNamesAndExport(List<String> workFlowColumnNames, List<ParticipantDataDto> allParticipantData, int instanceId) {
         DDPInstance ddpInstance = DDPInstance.getDDPInstanceById(instanceId);
+        Optional<String> maybeEsParticipantIndex =
+                new DDPInstanceDao().getEsParticipantIndexByInstanceId(instanceId);
         for (ParticipantDataDto participantData: allParticipantData) {
             String data = participantData.getData();
             if (data == null) {
+                continue;
+            }
+            String ddpParticipantId = participantData.getDdpParticipantId();
+            if (ddpParticipantId.length() > 20) {
+                ddpParticipantId = getGuidIfWeHaveAltpid(ddpParticipantId, maybeEsParticipantIndex);
+            }
+            if ("".equals(ddpParticipantId)) {
                 continue;
             }
             Map<String, String> dataMap = gson.fromJson(data, Map.class);
@@ -139,26 +154,37 @@ public class ExportToES {
                             || !dataMap.containsKey(FamilyMemberConstants.FIRSTNAME) || !dataMap.containsKey(FamilyMemberConstants.LASTNAME)) {
                         continue;
                     }
-                    if (hasProbandEmail(participantData.getDdpParticipantId(),
+                    if (hasProbandEmail(ddpParticipantId,
                             dataMap.get(FamilyMemberConstants.COLLABORATOR_PARTICIPANT_ID), allParticipantData)) {
                         WorkflowForES.StudySpecificData studySpecificData = new WorkflowForES.StudySpecificData(
                                 dataMap.get(FamilyMemberConstants.COLLABORATOR_PARTICIPANT_ID),
                                 dataMap.get(FamilyMemberConstants.FIRSTNAME),
                                 dataMap.get(FamilyMemberConstants.LASTNAME)
                         );
-                        ElasticSearchUtil.writeWorkflow(WorkflowForES.createInstanceWithStudySpecificData(ddpInstance, participantData.getDdpParticipantId(),
+                        ElasticSearchUtil.writeWorkflow(WorkflowForES.createInstanceWithStudySpecificData(ddpInstance, ddpParticipantId,
                                 entry.getKey(), entry.getValue(), studySpecificData));
                     }
                 } else {
-                    ElasticSearchUtil.writeWorkflow(WorkflowForES.createInstance(ddpInstance, participantData.getDdpParticipantId(),
+                    ElasticSearchUtil.writeWorkflow(WorkflowForES.createInstance(ddpInstance, ddpParticipantId,
                             entry.getKey(), entry.getValue()));
                 }
             }
             if (dataMap.containsKey(FamilyMemberConstants.FAMILY_ID)) {
                 ElasticSearchUtil.writeDsmRecord(ddpInstance, null,
-                        participantData.getDdpParticipantId(), ESObjectConstants.FAMILY_ID, dataMap.get(FAMILY_ID), null);
+                        ddpParticipantId, ESObjectConstants.FAMILY_ID, dataMap.get(FAMILY_ID), null);
             }
         }
+    }
+
+    public static String getGuidIfWeHaveAltpid(String ddpParticipantId, Optional<String> maybeEsParticipantIndex) {
+        if (maybeEsParticipantIndex.isPresent()) {
+            ElasticSearch participantESDataByAltpid =
+                    ElasticSearchUtil.getParticipantESDataByAltpid(maybeEsParticipantIndex.get(), ddpParticipantId);
+            ddpParticipantId = participantESDataByAltpid.getProfile().map(ESProfile::getParticipantGuid).orElse("");
+        } else {
+            logger.error("Wrong instance ID");
+        }
+        return ddpParticipantId;
     }
 
     private static List<String> findWorkFlowColumnNames(int instanceId) {

--- a/src/main/java/org/broadinstitute/dsm/model/elasticsearch/ESProfile.java
+++ b/src/main/java/org/broadinstitute/dsm/model/elasticsearch/ESProfile.java
@@ -16,6 +16,9 @@ public class ESProfile {
     @SerializedName(ESObjectConstants.GUID)
     private String participantGuid;
 
+    @SerializedName(ESObjectConstants.LEGACY_ALTPID)
+    private String legacyAltPid;
+
     @SerializedName(ESObjectConstants.EMAIL)
     private String email;
 

--- a/src/main/java/org/broadinstitute/dsm/statics/ESObjectConstants.java
+++ b/src/main/java/org/broadinstitute/dsm/statics/ESObjectConstants.java
@@ -47,4 +47,5 @@ public class ESObjectConstants {
     public static final String FIRST_NAME = "firstName";
     public static final String LAST_NAME = "lastName";
     public static final String GUID = "guid";
+    public static final String LEGACY_ALTPID = "legacyAltPid";
 }

--- a/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
@@ -224,12 +224,40 @@ public class ElasticSearchUtil {
         return elasticSearch;
     }
 
+    public static ElasticSearch getParticipantESDataByAltpid(@NonNull String index, @NonNull String altpid) {
+        ElasticSearch elasticSearch = new ElasticSearch.Builder().build();
+        try (RestHighLevelClient client = getClientForElasticsearchCloud(TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.ES_URL),
+                TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.ES_USERNAME), TransactionWrapper.getSqlFromConfig(ApplicationConfigConstants.ES_PASSWORD))) {
+            logger.info("Getting ES data for participant: " + altpid);
+            try {
+                elasticSearch = fetchESDataByAltpid(index, altpid, client);
+            }
+            catch (Exception e) {
+                throw new RuntimeException("Couldn't get ES for participant: " + altpid + " from " + index, e);
+            }
+            logger.info("Got ES data for participant: " + altpid + " from " + index);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return elasticSearch;
+    }
+
     public static ElasticSearch fetchESDataByParticipantId(String index, String participantId, RestHighLevelClient client) throws IOException {
         String matchQueryName = ParticipantUtil.isGuid(participantId) ? "profile.guid" : "profile.legacyAltPid";
+        return getElasticSearchForGivenMatch(index, participantId, client, matchQueryName);
+    }
+
+    public static ElasticSearch fetchESDataByAltpid(String index, String altpid, RestHighLevelClient client) throws IOException {
+        String matchQueryName = "profile.legacyAltPid";
+        return getElasticSearchForGivenMatch(index, altpid, client, matchQueryName);
+    }
+
+    public static ElasticSearch getElasticSearchForGivenMatch(String index, String id, RestHighLevelClient client, String matchQueryName) throws IOException {
         SearchRequest searchRequest = new SearchRequest(index);
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         SearchResponse response = null;
-        searchSourceBuilder.query(QueryBuilders.matchQuery(matchQueryName, participantId)).sort(PROFILE_CREATED_AT, SortOrder.ASC);
+        searchSourceBuilder.query(QueryBuilders.matchQuery(matchQueryName, id)).sort(PROFILE_CREATED_AT, SortOrder.ASC);
         searchSourceBuilder.size(1);
         searchSourceBuilder.from(0);
         searchRequest.source(searchSourceBuilder);

--- a/src/test/java/org/broadinstitute/dsm/ElasticSearchTest.java
+++ b/src/test/java/org/broadinstitute/dsm/ElasticSearchTest.java
@@ -419,6 +419,23 @@ public class ElasticSearchTest extends TestHelper {
         Assert.assertEquals(pIdToFilter, fetchedPid);
     }
 
+    @Test
+    public void testSearchParticipantByAltpid() {
+        String altpid = "c4aa8c50248beb9970ac94fc913ca7bbaa625726318b5705d7e42c9d9cede4b4";
+        String fetchedPid = "";
+        try (RestHighLevelClient client = ElasticSearchUtil.getClientForElasticsearchCloud(cfg.getString("elasticSearch.url"), cfg.getString("elasticSearch.username"), cfg.getString("elasticSearch.password"))) {
+            ElasticSearch esObject =
+                    ElasticSearchUtil.fetchESDataByAltpid("participants_structured.atcp.atcp", altpid, client);
+            fetchedPid = esObject.getProfile()
+                    .map(ESProfile::getLegacyAltPid)
+                    .orElse("");
+        } catch (IOException e) {
+            Assert.fail();
+            e.printStackTrace();
+        }
+        Assert.assertEquals(altpid, fetchedPid);
+    }
+
     public void notEmptyActivity(String index, String stableId, String activityCode) throws Exception {
         try (RestHighLevelClient client = ElasticSearchUtil.getClientForElasticsearchCloud(cfg.getString("elasticSearch.url"), cfg.getString("elasticSearch.username"), cfg.getString("elasticSearch.password"))) {
             int scrollSize = 1000;


### PR DESCRIPTION
When participants have altpids instead of guids, we are getting guid from ES ans updating workflows and family Id-s with it