### PR TITLE
Fix for ES querying

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/model/ParticipantWrapper.java
+++ b/src/main/java/org/broadinstitute/dsm/model/ParticipantWrapper.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -168,15 +169,27 @@ public class ParticipantWrapper {
             }
             //get all the list which were not filtered
             if (participantESData == null) {
+                participantESData = new HashMap<>();
                 //get only pts for the filtered data
-                if (baseList != null && !baseList.isEmpty()){
-                    String filter = Arrays.stream(baseList.toArray(new String[0])).collect(Collectors.joining(ElasticSearchUtil.BY_GUIDS));
-                    participantESData = ElasticSearchUtil.getFilteredDDPParticipantsFromES(instance, ElasticSearchUtil.BY_GUID + filter);
-                    if (instance.isMigratedDDP()) {//also check for legacyAltPid
-                        String filterLegacy = Arrays.stream(baseList.toArray(new String[0])).collect(Collectors.joining(ElasticSearchUtil.BY_LEGACY_ALTPIDS));
-                        Map<String, Map<String, Object>> tmp = ElasticSearchUtil.getFilteredDDPParticipantsFromES(instance, ElasticSearchUtil.BY_LEGACY_ALTPID + filterLegacy);
-                        participantESData = Stream.of(participantESData, tmp).flatMap(m -> m.entrySet().stream())
-                                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                if (baseList != null && !baseList.isEmpty()) {
+                    //ES can only filter for 1024 (too_many_clauses: maxClauseCount is set to 1024)
+                    if (baseList.size() > 1000) {
+                        //make sub-searches
+                        Collection<List<String>> partitionBaseList = partitionBasedOnSize(baseList, 1000);
+                        for (Iterator i = partitionBaseList.iterator(); i.hasNext();) {
+                            List<String> baseListPart = ((List<String>) i.next());
+                            participantESData = addParticipantESData(instance, baseListPart, participantESData, ElasticSearchUtil.BY_GUID, ElasticSearchUtil.BY_GUIDS);
+                            if (instance.isMigratedDDP()) {//also check for legacyAltPid
+                                participantESData = addParticipantESData(instance, baseListPart, participantESData, ElasticSearchUtil.BY_LEGACY_ALTPID, ElasticSearchUtil.BY_LEGACY_ALTPIDS);
+                            }
+                        }
+                    }
+                    else {
+                        //just search
+                        participantESData = addParticipantESData(instance, baseList, participantESData, ElasticSearchUtil.BY_GUID, ElasticSearchUtil.BY_GUIDS);
+                        if (instance.isMigratedDDP()) {//also check for legacyAltPid
+                            participantESData = addParticipantESData(instance, baseList, participantESData, ElasticSearchUtil.BY_LEGACY_ALTPID, ElasticSearchUtil.BY_LEGACY_ALTPIDS);
+                        }
                     }
                 }
                 else {
@@ -232,6 +245,20 @@ public class ParticipantWrapper {
             List<ParticipantWrapper> r = addAllData(baseList, participantESData, participants, medicalRecords, oncHistories, kitRequests, abstractionActivities, abstractionSummary, proxyData, participantData);
             return r;
         }
+    }
+
+    private static <String> Collection<List<String>> partitionBasedOnSize(List<String> inputList, int size) {
+        final AtomicInteger counter = new AtomicInteger(0);
+        return inputList.stream()
+                .collect(Collectors.groupingBy(s -> counter.getAndIncrement()/size))
+                .values();
+    }
+
+    private static Map<String, Map<String, Object>> addParticipantESData(DDPInstance instance, List<String> baseList, Map<String, Map<String, Object>> participantESData, String andCommand, String orCommand) {
+        String filterLegacy = Arrays.stream(baseList.toArray(new String[0])).collect(Collectors.joining(orCommand));
+        Map<String, Map<String, Object>> tmp = ElasticSearchUtil.getFilteredDDPParticipantsFromES(instance, andCommand + filterLegacy);
+        return Stream.of(participantESData, tmp).flatMap(m -> m.entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     private static void sortBySelfElseById(Map<String, List<ParticipantData>> participantData) {

--- a/src/main/java/org/broadinstitute/dsm/model/ParticipantWrapper.java
+++ b/src/main/java/org/broadinstitute/dsm/model/ParticipantWrapper.java
@@ -10,7 +10,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsm.db.*;
 import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
 import org.broadinstitute.dsm.model.participant.data.FamilyMemberConstants;
-import org.broadinstitute.dsm.model.rgp.AutomaticProbandDataCreator;
 import org.broadinstitute.dsm.model.at.DefaultValues;
 import org.broadinstitute.dsm.statics.DBConstants;
 import org.broadinstitute.dsm.util.ElasticSearchUtil;


### PR DESCRIPTION
https://broadinstitute.atlassian.net/browse/DDP-6503
https://broadinstitute.atlassian.net/browse/DDP-6506

ES throws an error if we query for more than 1024 guid or legacyAltPID
making sub queries now when we have over 1000 pts till we change how DSM is getting the pt list (only asking for the pts which are displayed on page 1)