### PR TITLE
Ddp 6541 fix to work on both studies

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/model/participant/data/FamilyMemberConstants.java
+++ b/src/main/java/org/broadinstitute/dsm/model/participant/data/FamilyMemberConstants.java
@@ -17,4 +17,5 @@ public class FamilyMemberConstants {
     public static final String RELATIONSHIP_ID = "COLLABORATOR_PARTICIPANT_ID";
 
     public static final String GROUP = "GROUP";
+    public static final String PARTICIPANTS = "PARTICIPANTS";
 }

--- a/src/main/java/org/broadinstitute/dsm/pubsub/WorkflowStatusUpdate.java
+++ b/src/main/java/org/broadinstitute/dsm/pubsub/WorkflowStatusUpdate.java
@@ -49,7 +49,7 @@ public class WorkflowStatusUpdate {
             FieldSettingsDto setting = fieldSetting.get();
             boolean isOldParticipant = participantDatas.stream()
                     .anyMatch(participantDataDto -> participantDataDto.getFieldTypeId().equals(setting.getFieldType())
-                            || !participantDataDto.getFieldTypeId().contains(FamilyMemberConstants.GROUP));
+                            || participantDataDto.getFieldTypeId().contains(FamilyMemberConstants.PARTICIPANTS));
             if (isOldParticipant) {
                 participantDatas.forEach(participantDataDto -> {
                     updateProbandStatusInDB(workflow, status, participantDataDto, studyGuid);
@@ -71,7 +71,7 @@ public class WorkflowStatusUpdate {
         Value[] actionsArray =  gson.fromJson(actions, Value[].class);
         for (Value action : actionsArray) {
             if (ESObjectConstants.ELASTIC_EXPORT_WORKFLOWS.equals(action.getType())) {
-                if (setting.getFieldType().contains(FamilyMemberConstants.GROUP)) {
+                if (!setting.getFieldType().contains(FamilyMemberConstants.PARTICIPANTS)) {
                     ElasticSearchUtil.writeWorkflow(WorkflowForES.createInstance(instance, ddpParticipantId, workflow, status), false);
                 } else {
                     Optional<WorkflowForES.StudySpecificData> studySpecificDataOptional = getProbandStudySpecificData(participantDatas);

--- a/src/main/java/org/broadinstitute/dsm/route/FilterRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/FilterRoute.java
@@ -301,12 +301,12 @@ public class FilterRoute extends RequestHandler {
         Map<String, String> participantIdsForQuery = new HashMap();
         Map<String, String> participantsNotToAdd = new HashMap();
         for (ParticipantDataDto participantData : allParticipantData) {
-            String data = participantData.getData();
-            String fieldTypeId = participantData.getFieldTypeId();
+            String data = participantData.getData().orElse(null);
+            String fieldTypeId = participantData.getFieldTypeId().orElse(null);
             if (data == null || fieldTypeId == null) {
                 continue;
             }
-            String ddpParticipantId = participantData.getDdpParticipantId();
+            String ddpParticipantId = participantData.getDdpParticipantId().orElse(null);
             Map<String, String> dataMap = gson.fromJson(data, Map.class);
             boolean questionWithOptions = (OPTIONS.equals(filter.getType()) || RADIO.equals(filter.getType())) && filter.getSelectedOptions() != null;
             boolean notEmptyCheck = filter.isNotEmpty() && dataMap.get(fieldName) != null && !dataMap.get(fieldName).isEmpty();

--- a/src/main/java/org/broadinstitute/dsm/route/FilterRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/FilterRoute.java
@@ -48,6 +48,7 @@ public class FilterRoute extends RequestHandler {
     private static final Logger logger = LoggerFactory.getLogger(FilterRoute.class);
     private static final Gson gson = new Gson();
     private static final ParticipantDataDao participantDataDao = new ParticipantDataDao();
+    public static final String PARTICIPANTS = "PARTICIPANTS";
     private static Pattern DATE_PATTERN = Pattern.compile(
             "^\\d{4}-\\d{2}-\\d{2}$");
 
@@ -297,10 +298,12 @@ public class FilterRoute extends RequestHandler {
 
     public static void addParticipantDataFilters(Map<String, String> queryConditions,
                                                  Filter filter, String fieldName, List<ParticipantDataDto> allParticipantData) {
-        List<String> participantIdsForQuery = new ArrayList<>();
+        Map<String, String> participantIdsForQuery = new HashMap();
+        Map<String, String> participantsNotToAdd = new HashMap();
         for (ParticipantDataDto participantData : allParticipantData) {
             String data = participantData.getData();
-            if (data == null) {
+            String fieldTypeId = participantData.getFieldTypeId();
+            if (data == null || fieldTypeId == null) {
                 continue;
             }
             String ddpParticipantId = participantData.getDdpParticipantId();
@@ -308,15 +311,24 @@ public class FilterRoute extends RequestHandler {
             boolean questionWithOptions = (OPTIONS.equals(filter.getType()) || RADIO.equals(filter.getType())) && filter.getSelectedOptions() != null;
             boolean notEmptyCheck = filter.isNotEmpty() && dataMap.get(fieldName) != null && !dataMap.get(fieldName).isEmpty();
             boolean emptyCheck = filter.isEmpty() && (dataMap.get(fieldName) == null || dataMap.get(fieldName).isEmpty());
-            if (notEmptyCheck || emptyCheck) {
-                participantIdsForQuery.add(ddpParticipantId);
+            if (notEmptyCheck || emptyCheck && !participantsNotToAdd.containsKey(ddpParticipantId)) {
+                participantIdsForQuery.put(ddpParticipantId, fieldName);
                 continue;
             }
+            //For the participants, which are saved in several rows (for example AT participants)
+            boolean shouldNotHaveBeenAdded = filter.isEmpty() && !(dataMap.get(fieldName) == null || dataMap.get(fieldName).isEmpty())
+                    && !fieldTypeId.contains(PARTICIPANTS);
+            if (shouldNotHaveBeenAdded) {
+                participantIdsForQuery.remove(ddpParticipantId);
+                participantsNotToAdd.put(ddpParticipantId, fieldName);
+                continue;
+            }
+
             if (questionWithOptions) {
                 for (String option : filter.getSelectedOptions()) {
                     if (dataMap.get(fieldName) != null && dataMap.get(fieldName)
                             .equals(option)) {
-                        participantIdsForQuery.add(ddpParticipantId);
+                        participantIdsForQuery.put(ddpParticipantId, fieldName);
                         break;
                     }
                 }
@@ -324,7 +336,7 @@ public class FilterRoute extends RequestHandler {
                 boolean singleValue = dataMap.get(fieldName) != null && dataMap.get(fieldName)
                         .equals(filter.getFilter1().getValue());
                 if (singleValue) {
-                    participantIdsForQuery.add(ddpParticipantId);
+                    participantIdsForQuery.put(ddpParticipantId, fieldName);
                 } else if (filter.getFilter2() != null) {
                     addConditionForRange(filter, fieldName, dataMap, participantIdsForQuery, ddpParticipantId);
                 }
@@ -342,20 +354,21 @@ public class FilterRoute extends RequestHandler {
         }
     }
 
-    public static StringBuilder getNewCondition(List<String> participantIdsForQuery) {
+    public static StringBuilder getNewCondition(Map<String, String> participantIdsForQuery) {
         StringBuilder newCondition = new StringBuilder(ElasticSearchUtil.AND);
-        for (int i = 0; i < participantIdsForQuery.size(); i++) {
-            String id = participantIdsForQuery.get(i);
+        int i = 0;
+        for (String id : participantIdsForQuery.keySet()) {
             if (i == 0) {
                 newCondition.append(ParticipantUtil.isGuid(id) ? ElasticSearchUtil.BY_PROFILE_GUID + id : ElasticSearchUtil.BY_PROFILE_LEGACY_ALTPID + id);
             } else {
                 newCondition.append(ParticipantUtil.isGuid(id) ? ElasticSearchUtil.BY_GUIDS + id : ElasticSearchUtil.BY_LEGACY_ALTPIDS + id);
             }
+            i++;
         }
         return newCondition;
     }
 
-    public static void addConditionForRange(Filter filter, String fieldName, Map<String, String> dataMap, List<String> participantIdsForQuery, String ddpParticipantId) {
+    public static void addConditionForRange(Filter filter, String fieldName, Map<String, String> dataMap, Map<String, String> participantIdsForQuery, String ddpParticipantId) {
         Object rangeValue1 = filter.getFilter1().getValue();
         Object rangeValue2 = filter.getFilter2().getValue();
         if (rangeValue1 == null || rangeValue2 == null) {
@@ -367,7 +380,7 @@ public class FilterRoute extends RequestHandler {
         boolean inDateRange = isInDateRange(fieldName, dataMap, rangeValue1, rangeValue2);
 
         if (inNumberRange || inDateRange) {
-            participantIdsForQuery.add(ddpParticipantId);;
+            participantIdsForQuery.put(ddpParticipantId, fieldName);
         }
     }
 

--- a/src/main/java/org/broadinstitute/dsm/route/PatchRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/PatchRoute.java
@@ -362,7 +362,7 @@ public class PatchRoute extends RequestHandler {
         Map<String, String> data = new Gson().fromJson(status, new TypeToken<Map<String, String>>() {
         }.getType());
         if (StringUtils.isNotBlank(action.getValue())) {
-            if (patch.getFieldId().contains(FamilyMemberConstants.GROUP)) {
+            if (!patch.getFieldId().contains(FamilyMemberConstants.PARTICIPANTS)) {
                 ElasticSearchUtil.writeWorkflow(WorkflowForES.createInstance(ddpInstance, patch.getParentId(), action.getName(), action.getValue()), false);
             }
             else if (ParticipantUtil.checkApplicantEmail(data.get(FamilyMemberConstants.COLLABORATOR_PARTICIPANT_ID),
@@ -375,7 +375,7 @@ public class PatchRoute extends RequestHandler {
             }
         }
         else if (StringUtils.isNotBlank(action.getName()) && data.containsKey(action.getName())) {
-            if (patch.getFieldId().contains(FamilyMemberConstants.GROUP)) {
+            if (!patch.getFieldId().contains(FamilyMemberConstants.PARTICIPANTS)) {
                 ElasticSearchUtil.writeWorkflow(WorkflowForES.createInstance(ddpInstance, patch.getParentId(), action.getName(), data.get(action.getName())), false);
             }
             else if (ParticipantUtil.checkApplicantEmail(data.get(FamilyMemberConstants.COLLABORATOR_PARTICIPANT_ID),

--- a/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
@@ -689,12 +689,14 @@ public class ElasticSearchUtil {
         for (String f : filters) {
             if (StringUtils.isNotBlank(f) && f.contains(DBConstants.ALIAS_DELIMITER)) {
                 if (f.contains(Filter.EQUALS) || f.contains(Filter.LIKE)) {
+                    BoolQueryBuilder innerQuery = new BoolQueryBuilder();
                     f = f.replace("(", "").replace(")", "").trim();
                     if (f.contains(Filter.OR)) {
                         String[] orValues = f.split(Filter.OR);
                         for (String or : orValues) {
-                            createQuery(finalQuery, or, false);
+                            createQuery(innerQuery, or, false);
                         }
+                        finalQuery.must(innerQuery);
                     }
                     else {
                         createQuery(finalQuery, f, true);

--- a/src/test/java/org/broadinstitute/dsm/FilterTest.java
+++ b/src/test/java/org/broadinstitute/dsm/FilterTest.java
@@ -28,6 +28,7 @@ public class FilterTest {
     private static Gson gson;
 
     private static final String participantId = "RBMJW6ZIXVXBMXUX6M3Q";
+    private static final String participantId1 = "RBMJW6ZIXVXBMXUX6M31";
 
     private static User user;
 
@@ -73,7 +74,7 @@ public class FilterTest {
         participantDataId = participantDataDao.create(participantDataDto);
 
         ParticipantDataDto participantDataDto1 =
-                new ParticipantDataDto(participantId, ddpInstanceDto.getDdpInstanceId(), FILTER_TEST,
+                new ParticipantDataDto(participantId1, ddpInstanceDto.getDdpInstanceId(), FILTER_TEST,
                         gson.toJson(participantData1), System.currentTimeMillis(), user.getEmail());
         participantDataId1 = participantDataDao.create(participantDataDto1);
     }
@@ -86,7 +87,7 @@ public class FilterTest {
         List<ParticipantDataDto> allParticipantData = participantDataDao
                 .getParticipantDataByInstanceid(Integer.parseInt(String.valueOf(ddpInstanceDto.getDdpInstanceId())));
         FilterRoute.addParticipantDataFilters(queryConditions, filter, filter.getFilter1().getName(), allParticipantData);
-        Assert.assertEquals("null AND (profile.guid = " + participantId + " OR profile.guid = " + participantId + ")",
+        Assert.assertEquals("null AND (profile.guid = " + participantId + " OR profile.guid = " + participantId1 + ")",
                 queryConditions.get(ElasticSearchUtil.ES));
     }
 
@@ -98,7 +99,7 @@ public class FilterTest {
         List<ParticipantDataDto> allParticipantData = participantDataDao
                 .getParticipantDataByInstanceid(Integer.parseInt(String.valueOf(ddpInstanceDto.getDdpInstanceId())));
         FilterRoute.addParticipantDataFilters(queryConditions, filter, filter.getFilter1().getName(), allParticipantData);
-        Assert.assertEquals("null AND (profile.guid = " + participantId + " OR profile.guid = " + participantId + ")",
+        Assert.assertEquals("null AND (profile.guid = " + participantId + " OR profile.guid = " + participantId1 + ")",
                 queryConditions.get(ElasticSearchUtil.ES));
     }
 
@@ -110,7 +111,7 @@ public class FilterTest {
         List<ParticipantDataDto> allParticipantData = participantDataDao
                 .getParticipantDataByInstanceid(Integer.parseInt(String.valueOf(ddpInstanceDto.getDdpInstanceId())));
         FilterRoute.addParticipantDataFilters(queryConditions, filter, filter.getFilter1().getName(), allParticipantData);
-        Assert.assertEquals("null AND (profile.guid = " + participantId + " OR profile.guid = " + participantId + ")",
+        Assert.assertEquals("null AND (profile.guid = " + participantId + " OR profile.guid = " + participantId1 + ")",
                 queryConditions.get(ElasticSearchUtil.ES));
     }
 
@@ -123,7 +124,7 @@ public class FilterTest {
         List<ParticipantDataDto> allParticipantData = participantDataDao
                 .getParticipantDataByInstanceid(Integer.parseInt(String.valueOf(ddpInstanceDto.getDdpInstanceId())));
         FilterRoute.addParticipantDataFilters(queryConditions, filter, filter.getFilter1().getName(), allParticipantData);
-        Assert.assertEquals("null AND (profile.guid = " + participantId + " OR profile.guid = " + participantId + ")",
+        Assert.assertEquals("null AND (profile.guid = " + participantId + " OR profile.guid = " + participantId1 + ")",
                 queryConditions.get(ElasticSearchUtil.ES));
     }
 
@@ -153,9 +154,9 @@ public class FilterTest {
         FilterRoute.addParticipantDataFilters(queryConditions, filterA, filterA.getFilter1().getName(), allParticipantData);
         FilterRoute.addParticipantDataFilters(queryConditions, filterB, filterB.getFilter1().getName(), allParticipantData);
         FilterRoute.addParticipantDataFilters(queryConditions, filterC, filterC.getFilter1().getName(), allParticipantData);
-        Assert.assertEquals("null AND (profile.guid = RBMJW6ZIXVXBMXUX6M3Q" + " OR profile.guid = " + participantId + ")" +
-                        " AND (profile.guid = RBMJW6ZIXVXBMXUX6M3Q" + " OR profile.guid = " + participantId + ")" +
-                        " AND (profile.guid = RBMJW6ZIXVXBMXUX6M3Q" + " OR profile.guid = " + participantId + ")",
+        Assert.assertEquals("null AND (profile.guid = RBMJW6ZIXVXBMXUX6M3Q" + " OR profile.guid = " + participantId1 + ")" +
+                        " AND (profile.guid = RBMJW6ZIXVXBMXUX6M3Q" + " OR profile.guid = " + participantId1 + ")" +
+                        " AND (profile.guid = RBMJW6ZIXVXBMXUX6M3Q" + " OR profile.guid = " + participantId1 + ")",
                 queryConditions.get(ElasticSearchUtil.ES));
     }
 

--- a/src/test/java/org/broadinstitute/dsm/FilterTest.java
+++ b/src/test/java/org/broadinstitute/dsm/FilterTest.java
@@ -80,8 +80,14 @@ public class FilterTest {
         participantDataId = participantDataDao.create(participantDataDto);
 
         ParticipantDataDto participantDataDto1 =
-                new ParticipantDataDto(participantId1, ddpInstanceDto.getDdpInstanceId(), FILTER_TEST,
-                        gson.toJson(participantData1), System.currentTimeMillis(), user.getEmail());
+                new ParticipantDataDto.Builder()
+                    .withDdpParticipantId(participantId1)
+                    .withDdpInstanceId(ddpInstanceDto.getDdpInstanceId())
+                    .withFieldTypeId(FILTER_TEST)
+                    .withData(gson.toJson(participantData1))
+                    .withLastChanged(System.currentTimeMillis())
+                    .withChangedBy(user.getEmail())
+                    .build();
         participantDataId1 = participantDataDao.create(participantDataDto1);
     }
 


### PR DESCRIPTION
Use participans in fieldTypeId to distinguish TABBED and TABGROUPED studies. In this case AT from RGP.
Use hashmap and add small change to make AT correctly filter after using "empty" tickmark. Reason is AT fields are saved in different rows.
Change query to make should nested into must, so that it fixes problem with several AND-s OR-s in query.