### PR TITLE
DDP-6643 fix ES lookup call when removing workflows in patch-route

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/model/elasticsearch/ESProfile.java
+++ b/src/main/java/org/broadinstitute/dsm/model/elasticsearch/ESProfile.java
@@ -20,7 +20,7 @@ public class ESProfile {
     private String email;
 
     @SerializedName(ESObjectConstants.LEGACY_ALTPID)
-    private String participantLegacyAlptid;
+    private String participantLegacyAltPid;
 
     @SerializedName(ESObjectConstants.HRUID)
     private String hruid;

--- a/src/main/java/org/broadinstitute/dsm/model/participant/data/ParticipantData.java
+++ b/src/main/java/org/broadinstitute/dsm/model/participant/data/ParticipantData.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -18,6 +17,7 @@ import org.broadinstitute.dsm.db.dao.Dao;
 import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
 import org.broadinstitute.dsm.db.dao.ddp.participant.ParticipantDataDao;
 import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantDataDto;
+import org.broadinstitute.dsm.model.elasticsearch.ESProfile;
 import org.broadinstitute.dsm.util.ParticipantUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -168,6 +168,13 @@ public class ParticipantData {
         String familyMemberEmail = this.data.get(FamilyMemberConstants.EMAIL);
         String esParticipantIndex = new DDPInstanceDao().getEsParticipantIndexByInstanceId(ddpInstanceId).orElse("");
         String applicantEmail = ParticipantUtil.getParticipantEmailById(esParticipantIndex, this.ddpParticipantId);
+        return applicantEmail.equals(familyMemberEmail);
+    }
+
+    public boolean hasFamilyMemberApplicantEmail(ESProfile applicantProfile) {
+        if (Objects.isNull(this.data) || StringUtils.isBlank(this.ddpParticipantId)) return false;
+        String familyMemberEmail = this.data.get(FamilyMemberConstants.EMAIL);
+        String applicantEmail = StringUtils.defaultIfBlank(applicantProfile.getEmail(), "");
         return applicantEmail.equals(familyMemberEmail);
     }
 

--- a/src/main/java/org/broadinstitute/dsm/model/rgp/AutomaticProbandDataCreator.java
+++ b/src/main/java/org/broadinstitute/dsm/model/rgp/AutomaticProbandDataCreator.java
@@ -62,8 +62,8 @@ public class AutomaticProbandDataCreator implements Defaultable {
                             fieldSettings.getColumnsWithDefaultOptions(fieldSettingsDtosByOptionAndInstanceId);
                     Map<String, String> columnsWithDefaultOptionsFilteredByElasticExportWorkflow =
                             fieldSettings.getColumnsWithDefaultOptionsFilteredByElasticExportWorkflow(fieldSettingsDtosByOptionAndInstanceId);
-                    String participantId = StringUtils.isNotBlank(esProfile.getParticipantLegacyAlptid())
-                            ? esProfile.getParticipantLegacyAlptid()
+                    String participantId = StringUtils.isNotBlank(esProfile.getParticipantLegacyAltPid())
+                            ? esProfile.getParticipantLegacyAltPid()
                             : esProfile.getParticipantGuid();
                     ParticipantData participantData = new ParticipantData(participantDataDao);
                     Optional<BookmarkDto> maybeFamilyIdOfBookmark = bookmarkDao.getBookmarkByInstance(RGP_FAMILY_ID);

--- a/src/test/java/org/broadinstitute/dsm/ElasticSearchTest.java
+++ b/src/test/java/org/broadinstitute/dsm/ElasticSearchTest.java
@@ -413,7 +413,7 @@ public class ElasticSearchTest extends TestHelper {
                     ElasticSearchUtil.fetchESDataByParticipantId("participants_structured.rgp.rgp", pIdToFilter, client);
             fetchedPid = esObject.orElse(new ElasticSearch.Builder().build())
                     .getProfile()
-                    .map(ESProfile::getParticipantLegacyAlptid)
+                    .map(ESProfile::getParticipantLegacyAltPid)
                     .orElse("");
         } catch (IOException e) {
             Assert.fail();
@@ -430,7 +430,7 @@ public class ElasticSearchTest extends TestHelper {
             ElasticSearch esObject =
                     ElasticSearchUtil.fetchESDataByAltpid("participants_structured.atcp.atcp", altpid, client);
             fetchedPid = esObject.getProfile()
-                    .map(ESProfile::getParticipantLegacyAlptid)
+                    .map(ESProfile::getParticipantLegacyAltPid)
                     .orElse("");
         } catch (IOException e) {
             Assert.fail();


### PR DESCRIPTION
Fixes DDP-6643.

When the email doesn't match the applicant email, we make a call to ES to fetch the workflow. The bug is that we're using the altpid for the doc ID instead of the participant guid. And in this case, for that particular account, we happened to have an old ES document with the altpid as doc ID. In that old document, we have workflows for one of the family members (who is not the one we're patching). Given how we're iterating and remove things from the workflow list, we ended up having an empty list. The sizes doesn't match up, so we issue an update request, and now we have no workflows.

This PR will fix the bug in the code, but we should also delete and recreate the indices for RGP in prod to get rid of any old/stale documents. 