### PR TITLE
refactor: don't use keep-alive connections to proxy in ES client

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
@@ -10,6 +10,7 @@ import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.NoConnectionReuseStrategy;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.lucene.search.join.ScoreMode;
 import org.broadinstitute.ddp.db.TransactionWrapper;
@@ -160,6 +161,7 @@ public class ElasticSearchUtil {
                     httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
                     if (proxyUrl != null) {
                         httpClientBuilder.setProxy(new HttpHost(proxyUrl.getHost(), proxyUrl.getPort(), proxyUrl.getProtocol()));
+                        httpClientBuilder.setConnectionReuseStrategy(NoConnectionReuseStrategy.INSTANCE);
                     }
                     return httpClientBuilder;
                 })


### PR DESCRIPTION
This is based on my fix on the DSS side. See https://github.com/broadinstitute/ddp-study-server/pull/536#discussion_r533615338.

CC @pegahtah @gmakharat @Irakli-Khaladze 