### PR TITLE
More than 1000 guids bugfix

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/model/Filter.java
+++ b/src/main/java/org/broadinstitute/dsm/model/Filter.java
@@ -45,6 +45,7 @@ public class Filter {
     public static final String JSON_EXTRACT = "JSON_EXTRACT";
     public static final String JSON_CONTAINS = "JSON_CONTAINS";
     public static final String JSON_OBJECT = "JSON_OBJECT";
+    public static final int THOUSAND = 1000;
 
     public static String TEXT = "TEXT";
     public static String OPTIONS = "OPTIONS";

--- a/src/main/java/org/broadinstitute/dsm/model/ParticipantWrapper.java
+++ b/src/main/java/org/broadinstitute/dsm/model/ParticipantWrapper.java
@@ -172,9 +172,9 @@ public class ParticipantWrapper {
                 //get only pts for the filtered data
                 if (baseList != null && !baseList.isEmpty()) {
                     //ES can only filter for 1024 (too_many_clauses: maxClauseCount is set to 1024)
-                    if (baseList.size() > 1000) {
+                    if (baseList.size() > Filter.THOUSAND) {
                         //make sub-searches
-                        Collection<List<String>> partitionBaseList = partitionBasedOnSize(baseList, 1000);
+                        Collection<List<String>> partitionBaseList = partitionBasedOnSize(baseList, Filter.THOUSAND);
                         for (Iterator i = partitionBaseList.iterator(); i.hasNext();) {
                             List<String> baseListPart = ((List<String>) i.next());
                             participantESData = addParticipantESData(instance, baseListPart, participantESData, ElasticSearchUtil.BY_GUID, ElasticSearchUtil.BY_GUIDS);
@@ -252,18 +252,18 @@ public class ParticipantWrapper {
         String[] betweenAnds = wholeFilter.split(Filter.AND_TRIMMED);
         boolean tooManyParameters = false;
         participantESData = new HashMap<>();
-        String lessThanLimit = Arrays.stream(betweenAnds).filter(query -> query.split(Filter.OR_TRIMMED).length <= 900).collect(Collectors.joining(Filter.AND));
+        String lessThanLimit = Arrays.stream(betweenAnds).filter(query -> query.split(Filter.OR_TRIMMED).length <= Filter.THOUSAND).collect(Collectors.joining(Filter.AND));
         for (String query: betweenAnds) {
             String[] orQueries = query.split(Filter.OR_TRIMMED);
-            if (orQueries.length <= 900) {
+            if (orQueries.length <= Filter.THOUSAND) {
                 continue;
             }
             tooManyParameters = true;
-            Collection<List<String>> partitionBaseList = partitionBasedOnSize(Arrays.asList(orQueries), 900);
+            Collection<List<String>> partitionBaseList = partitionBasedOnSize(Arrays.asList(orQueries), Filter.THOUSAND);
             for (Iterator i = partitionBaseList.iterator(); i.hasNext();) {
                 List<String> baseListPart = ((List<String>) i.next());
                 Map<String, Map<String, Object>> tempParticipantESData = ElasticSearchUtil
-                        .getFilteredDDPParticipantsFromES(instance, lessThanLimit + " AND " + String.join(Filter.OR, baseListPart));
+                        .getFilteredDDPParticipantsFromES(instance, lessThanLimit + Filter.AND + String.join(Filter.OR, baseListPart));
                 if (tempParticipantESData != null) {
                     participantESData.putAll(tempParticipantESData);
                 }

--- a/src/main/java/org/broadinstitute/dsm/model/ParticipantWrapper.java
+++ b/src/main/java/org/broadinstitute/dsm/model/ParticipantWrapper.java
@@ -161,6 +161,9 @@ public class ParticipantWrapper {
                     //                    baseList = getCommonEntries(baseList, new ArrayList<>(abstractionSummary.keySet()));
                     //                }
                     else { //source is not of any study-manager table so it must be ES
+                        String wholeFilter = filters.get(source);
+                        String[] ands = wholeFilter.split("AND");
+                        int or = Arrays.stream(ands).flatMap(and -> Arrays.stream(and.split("OR"))).collect(Collectors.toList()).size();
                         participantESData = ElasticSearchUtil.getFilteredDDPParticipantsFromES(instance, filters.get(source));
                         baseList = getCommonEntries(baseList, new ArrayList<>(participantESData.keySet()));
                     }

--- a/src/main/java/org/broadinstitute/dsm/route/FilterRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/FilterRoute.java
@@ -302,25 +302,33 @@ public class FilterRoute extends RequestHandler {
 
     public static void addParticipantDataConditionsToQuery(Map<String, Integer> allIdsForParticipantDataFiltering, Map<String, String> queryConditions, int filtersLength) {
         StringBuilder newCondition = new StringBuilder(ElasticSearchUtil.AND);
-        int i = 0;
         if (allIdsForParticipantDataFiltering.isEmpty()) {
             queryConditions.put(ElasticSearchUtil.ES, ElasticSearchUtil.BY_PROFILE_GUID + ElasticSearchUtil.EMPTY);
         } else {
-            for (Map.Entry<String, Integer> entry: allIdsForParticipantDataFiltering.entrySet()) {
-                if (entry.getValue() != filtersLength) {
-                    continue;
-                }
-                if (i == 0) {
-                    newCondition.append(ParticipantUtil.isGuid(entry.getKey()) ? ElasticSearchUtil.BY_PROFILE_GUID + entry.getKey() : ElasticSearchUtil.BY_PROFILE_LEGACY_ALTPID + entry.getKey());
-                } else {
-                    newCondition.append(ParticipantUtil.isGuid(entry.getKey()) ? ElasticSearchUtil.BY_GUIDS + entry.getKey() : ElasticSearchUtil.BY_LEGACY_ALTPIDS + entry.getKey());
-                }
-                i++;
-            }
+            createNewConditionByIds(allIdsForParticipantDataFiltering, filtersLength, newCondition);
             newCondition.append(ElasticSearchUtil.CLOSING_PARENTHESIS);
-            String esCondition = queryConditions.get(ElasticSearchUtil.ES);
-            esCondition += newCondition.toString();
+             String esCondition = queryConditions.get(ElasticSearchUtil.ES);
+            if (esCondition == null) {
+                esCondition = newCondition.toString();
+            } else {
+                esCondition += newCondition.toString();
+            }
             queryConditions.put(ElasticSearchUtil.ES, esCondition);
+        }
+    }
+
+    public static void createNewConditionByIds(Map<String, Integer> allIdsForParticipantDataFiltering, int filtersLength, StringBuilder newCondition) {
+        int i = 0;
+        for (Map.Entry<String, Integer> entry: allIdsForParticipantDataFiltering.entrySet()) {
+            if (entry.getValue() != filtersLength) {
+                continue;
+            }
+            if (i == 0) {
+                newCondition.append(ParticipantUtil.isGuid(entry.getKey()) ? ElasticSearchUtil.BY_PROFILE_GUID + entry.getKey() : ElasticSearchUtil.BY_PROFILE_LEGACY_ALTPID + entry.getKey());
+            } else {
+                newCondition.append(ParticipantUtil.isGuid(entry.getKey()) ? ElasticSearchUtil.BY_GUIDS + entry.getKey() : ElasticSearchUtil.BY_LEGACY_ALTPIDS + entry.getKey());
+            }
+            i++;
         }
     }
 

--- a/src/main/java/org/broadinstitute/dsm/route/FilterRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/FilterRoute.java
@@ -301,17 +301,16 @@ public class FilterRoute extends RequestHandler {
     }
 
     public static void addParticipantDataConditionsToQuery(Map<String, Integer> allIdsForParticipantDataFiltering, Map<String, String> queryConditions, int filtersLength) {
-        StringBuilder newCondition = new StringBuilder(ElasticSearchUtil.AND);
         if (allIdsForParticipantDataFiltering.isEmpty()) {
             queryConditions.put(ElasticSearchUtil.ES, ElasticSearchUtil.BY_PROFILE_GUID + ElasticSearchUtil.EMPTY);
         } else {
-            createNewConditionByIds(allIdsForParticipantDataFiltering, filtersLength, newCondition);
-            newCondition.append(ElasticSearchUtil.CLOSING_PARENTHESIS);
-            queryConditions.merge(ElasticSearchUtil.ES, newCondition.toString(), (prev, next) -> prev + next);
+            String newCondition = createNewConditionByIds(allIdsForParticipantDataFiltering, filtersLength);
+            queryConditions.merge(ElasticSearchUtil.ES, newCondition, (prev, next) -> prev + next);
         }
     }
 
-    public static void createNewConditionByIds(Map<String, Integer> allIdsForParticipantDataFiltering, int filtersLength, StringBuilder newCondition) {
+    public static String createNewConditionByIds(Map<String, Integer> allIdsForParticipantDataFiltering, int filtersLength) {
+        StringBuilder newCondition = new StringBuilder(ElasticSearchUtil.AND);
         int i = 0;
         for (Map.Entry<String, Integer> entry: allIdsForParticipantDataFiltering.entrySet()) {
             if (entry.getValue() != filtersLength) {
@@ -324,6 +323,8 @@ public class FilterRoute extends RequestHandler {
             }
             i++;
         }
+        newCondition.append(ElasticSearchUtil.CLOSING_PARENTHESIS);
+        return newCondition.toString();
     }
 
     public static void addParticipantDataIdsForFilters(Filter filter, String fieldName, List<ParticipantDataDto> allParticipantData,

--- a/src/main/java/org/broadinstitute/dsm/route/FilterRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/FilterRoute.java
@@ -307,13 +307,7 @@ public class FilterRoute extends RequestHandler {
         } else {
             createNewConditionByIds(allIdsForParticipantDataFiltering, filtersLength, newCondition);
             newCondition.append(ElasticSearchUtil.CLOSING_PARENTHESIS);
-             String esCondition = queryConditions.get(ElasticSearchUtil.ES);
-            if (esCondition == null) {
-                esCondition = newCondition.toString();
-            } else {
-                esCondition += newCondition.toString();
-            }
-            queryConditions.put(ElasticSearchUtil.ES, esCondition);
+            queryConditions.merge(ElasticSearchUtil.ES, newCondition.toString(), (prev, next) -> prev + next);
         }
     }
 

--- a/src/main/java/org/broadinstitute/dsm/route/FilterRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/FilterRoute.java
@@ -243,6 +243,8 @@ public class FilterRoute extends RequestHandler {
         Map<String, String> queryConditions = new HashMap<>();
         List<ParticipantDataDto> allParticipantData = null;
         if (filters != null && columnNameMap != null && !columnNameMap.isEmpty()) {
+            Map<String, Integer> allIdsForParticipantDataFiltering = new HashMap<>();
+            int numberOfParticipantDataFilters = 0;
             for (Filter filter : filters) {
                 if (filter != null) {
                     String tmp = null;
@@ -261,7 +263,8 @@ public class FilterRoute extends RequestHandler {
                             allParticipantData = participantDataDao
                                     .getParticipantDataByInstanceId(Integer.parseInt(instance.getDdpInstanceId()));
                         }
-                        addParticipantDataFilters(queryConditions, filter, tmpName, allParticipantData);
+                        numberOfParticipantDataFilters++;
+                        addParticipantDataIdsForFilters(filter, tmpName, allParticipantData, allIdsForParticipantDataFiltering);
                     } else {
                         if (StringUtils.isNotBlank(tmpName)) {
                             dbElement = columnNameMap.get(tmp + "." + tmpName);
@@ -270,6 +273,7 @@ public class FilterRoute extends RequestHandler {
                     }
                 }
             }
+            addParticipantDataConditionsToQuery(allIdsForParticipantDataFiltering, queryConditions, numberOfParticipantDataFilters);
         }
 
         if (!queryConditions.isEmpty()) {
@@ -296,8 +300,32 @@ public class FilterRoute extends RequestHandler {
         }
     }
 
-    public static void addParticipantDataFilters(Map<String, String> queryConditions,
-                                                 Filter filter, String fieldName, List<ParticipantDataDto> allParticipantData) {
+    public static void addParticipantDataConditionsToQuery(Map<String, Integer> allIdsForParticipantDataFiltering, Map<String, String> queryConditions, int filtersLength) {
+        StringBuilder newCondition = new StringBuilder(ElasticSearchUtil.AND);
+        int i = 0;
+        if (allIdsForParticipantDataFiltering.isEmpty()) {
+            queryConditions.put(ElasticSearchUtil.ES, ElasticSearchUtil.BY_PROFILE_GUID + ElasticSearchUtil.EMPTY);
+        } else {
+            for (Map.Entry<String, Integer> entry: allIdsForParticipantDataFiltering.entrySet()) {
+                if (entry.getValue() != filtersLength) {
+                    continue;
+                }
+                if (i == 0) {
+                    newCondition.append(ParticipantUtil.isGuid(entry.getKey()) ? ElasticSearchUtil.BY_PROFILE_GUID + entry.getKey() : ElasticSearchUtil.BY_PROFILE_LEGACY_ALTPID + entry.getKey());
+                } else {
+                    newCondition.append(ParticipantUtil.isGuid(entry.getKey()) ? ElasticSearchUtil.BY_GUIDS + entry.getKey() : ElasticSearchUtil.BY_LEGACY_ALTPIDS + entry.getKey());
+                }
+                i++;
+            }
+            newCondition.append(ElasticSearchUtil.CLOSING_PARENTHESIS);
+            String esCondition = queryConditions.get(ElasticSearchUtil.ES);
+            esCondition += newCondition.toString();
+            queryConditions.put(ElasticSearchUtil.ES, esCondition);
+        }
+    }
+
+    public static void addParticipantDataIdsForFilters(Filter filter, String fieldName, List<ParticipantDataDto> allParticipantData,
+                                                       Map<String, Integer> allIdsForParticipantDataFiltering) {
         Map<String, String> participantIdsForQuery = new HashMap();
         Map<String, String> participantsNotToAdd = new HashMap();
         for (ParticipantDataDto participantData : allParticipantData) {
@@ -348,16 +376,8 @@ public class FilterRoute extends RequestHandler {
                 }
             }
         }
-        if (!participantIdsForQuery.isEmpty()) {
-            StringBuilder newCondition = getNewCondition(participantIdsForQuery);
-            newCondition.append(ElasticSearchUtil.CLOSING_PARENTHESIS);
-            String esCondition = queryConditions.get(ElasticSearchUtil.ES);
-            esCondition += newCondition.toString();
-            queryConditions.put(ElasticSearchUtil.ES, esCondition);
-        } else {
-            //so that empty list is returned
-            queryConditions.put(ElasticSearchUtil.ES, ElasticSearchUtil.BY_PROFILE_GUID + ElasticSearchUtil.EMPTY);
-        }
+        participantIdsForQuery.forEach((key, value) -> allIdsForParticipantDataFiltering
+                .put(key, allIdsForParticipantDataFiltering.getOrDefault(key, 0) + 1));
     }
 
     public static StringBuilder getNewCondition(Map<String, String> participantIdsForQuery) {

--- a/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
@@ -1205,7 +1205,7 @@ public class ElasticSearchUtil {
             if (wildCard) {
                 userEntered = userEntered.replaceAll("%", "").trim();
             }
-            if (nameValue[0].startsWith(PROFILE)) {
+            if (nameValue[0].strip().startsWith(PROFILE)) {
                 if (nameValue[0].trim().endsWith(ESObjectConstants.HRUID) || nameValue[0].trim().endsWith("legacyShortId") ||
                         nameValue[0].trim().endsWith(GUID) || nameValue[0].trim().endsWith(LEGACY_ALT_PID)) {
                     valueQueryBuilder(finalQuery, nameValue[0].trim(), userEntered, wildCard, must);

--- a/src/test/java/org/broadinstitute/dsm/FilterTest.java
+++ b/src/test/java/org/broadinstitute/dsm/FilterTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsm;
 
 import com.google.gson.Gson;
+import jnr.ffi.annotations.In;
 import org.broadinstitute.dsm.db.dto.user.UserDto;
 import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
 import org.broadinstitute.dsm.db.dao.ddp.participant.ParticipantDataDao;
@@ -94,11 +95,13 @@ public class FilterTest {
     @Test
     public void testAddOneParticipantDataFilter() {
         Map<String, String> queryConditions = new HashMap<>();
+        Map<String, Integer> allParticipantDataForFiltering = new HashMap<>();
         Filter filter = new Filter(false, true, false, false, "DATE", "participantData",
                 new NameValue("PARTICIPANT_DEATH_DATE", "2040-10-30"), null, null, null);
         List<ParticipantDataDto> allParticipantData = participantDataDao
                 .getParticipantDataByInstanceId(Integer.parseInt(String.valueOf(ddpInstanceDto.getDdpInstanceId())));
-        FilterRoute.addParticipantDataFilters(queryConditions, filter, filter.getFilter1().getName(), allParticipantData);
+        FilterRoute.addParticipantDataIdsForFilters(filter, filter.getFilter1().getName(), allParticipantData, allParticipantDataForFiltering);
+        FilterRoute.addParticipantDataConditionsToQuery(allParticipantDataForFiltering, queryConditions, 1);
         Assert.assertEquals("null AND (profile.guid = " + participantId + " OR profile.guid = " + participantId1 + ")",
                 queryConditions.get(ElasticSearchUtil.ES));
     }
@@ -106,11 +109,13 @@ public class FilterTest {
     @Test
     public void testAddOneParticipantDataFilterNotEmpty() {
         Map<String, String> queryConditions = new HashMap<>();
+        Map<String, Integer> allParticipantDataForFiltering = new HashMap<>();
         Filter filter = new Filter(false, true, false, true, "DATE", "participantData",
                 new NameValue("PARTICIPANT_DEATH_DATE", "2040-10-35"), null, null, null);
         List<ParticipantDataDto> allParticipantData = participantDataDao
                 .getParticipantDataByInstanceId(Integer.parseInt(String.valueOf(ddpInstanceDto.getDdpInstanceId())));
-        FilterRoute.addParticipantDataFilters(queryConditions, filter, filter.getFilter1().getName(), allParticipantData);
+        FilterRoute.addParticipantDataIdsForFilters(filter, filter.getFilter1().getName(), allParticipantData, allParticipantDataForFiltering);
+        FilterRoute.addParticipantDataConditionsToQuery(allParticipantDataForFiltering, queryConditions, 1);
         Assert.assertEquals("null AND (profile.guid = " + participantId + " OR profile.guid = " + participantId1 + ")",
                 queryConditions.get(ElasticSearchUtil.ES));
     }
@@ -118,11 +123,13 @@ public class FilterTest {
     @Test
     public void testAddOneParticipantDataFilterEmpty() {
         Map<String, String> queryConditions = new HashMap<>();
+        Map<String, Integer> allParticipantDataForFiltering = new HashMap<>();
         Filter filter = new Filter(false, true, true, false, "DATE", "participantData",
                 new NameValue("PARTICIPANT_NONEXISTENT_DATE", "2040-10-35"), null, null, null);
         List<ParticipantDataDto> allParticipantData = participantDataDao
                 .getParticipantDataByInstanceId(Integer.parseInt(String.valueOf(ddpInstanceDto.getDdpInstanceId())));
-        FilterRoute.addParticipantDataFilters(queryConditions, filter, filter.getFilter1().getName(), allParticipantData);
+        FilterRoute.addParticipantDataIdsForFilters(filter, filter.getFilter1().getName(), allParticipantData, allParticipantDataForFiltering);
+        FilterRoute.addParticipantDataConditionsToQuery(allParticipantDataForFiltering, queryConditions, 1);
         Assert.assertEquals("null AND (profile.guid = " + participantId + " OR profile.guid = " + participantId1 + ")",
                 queryConditions.get(ElasticSearchUtil.ES));
     }
@@ -130,12 +137,14 @@ public class FilterTest {
     @Test
     public void testAddOneParticipantDataWithRange() {
         Map<String, String> queryConditions = new HashMap<>();
+        Map<String, Integer> allParticipantDataForFiltering = new HashMap<>();
         Filter filter = new Filter(false, true, false, false, "DATE", "participantData",
                 new NameValue("PARTICIPANT_DEATH_DATE", "2040-10-29"),
                 new NameValue("PARTICIPANT_DEATH_DATE", "2040-10-31"), null, null);
         List<ParticipantDataDto> allParticipantData = participantDataDao
                 .getParticipantDataByInstanceId(Integer.parseInt(String.valueOf(ddpInstanceDto.getDdpInstanceId())));
-        FilterRoute.addParticipantDataFilters(queryConditions, filter, filter.getFilter1().getName(), allParticipantData);
+        FilterRoute.addParticipantDataIdsForFilters(filter, filter.getFilter1().getName(), allParticipantData, allParticipantDataForFiltering);
+        FilterRoute.addParticipantDataConditionsToQuery(allParticipantDataForFiltering, queryConditions, 1);
         Assert.assertEquals("null AND (profile.guid = " + participantId + " OR profile.guid = " + participantId1 + ")",
                 queryConditions.get(ElasticSearchUtil.ES));
     }
@@ -143,18 +152,22 @@ public class FilterTest {
     @Test
     public void testAddOneParticipantDataWithRangeFalse() {
         Map<String, String> queryConditions = new HashMap<>();
+        Map<String, Integer> allParticipantDataForFiltering = new HashMap<>();
         Filter filter = new Filter(false, true, false, false, "DATE", "participantData",
                 new NameValue("PARTICIPANT_DEATH_DATE", "2020-10-29"),
                 new NameValue("PARTICIPANT_DEATH_DATE", "2020-10-31"), null, null);
         List<ParticipantDataDto> allParticipantData = participantDataDao
                 .getParticipantDataByInstanceId(Integer.parseInt(String.valueOf(ddpInstanceDto.getDdpInstanceId())));
-        FilterRoute.addParticipantDataFilters(queryConditions, filter, filter.getFilter1().getName(), allParticipantData);
+        FilterRoute.addParticipantDataIdsForFilters(filter, filter.getFilter1().getName(), allParticipantData, allParticipantDataForFiltering);
+        FilterRoute.addParticipantDataConditionsToQuery(allParticipantDataForFiltering, queryConditions, 1);
         Assert.assertEquals("profile.guid = empty", queryConditions.get(ElasticSearchUtil.ES));
     }
 
     @Test
     public void testAddSeveralParticipantDataFilter() {
         Map<String, String> queryConditions = new HashMap<>();
+        Map<String, String> queryConditions1 = new HashMap<>();
+        Map<String, Integer> allParticipantDataForFiltering = new HashMap<>();
         Filter filterA = new Filter(false, true, false, false, "DATE", "participantData",
                 new NameValue("PARTICIPANT_DEATH_DATE", "2040-10-30"), null, null, null);
         Filter filterB = new Filter(false, true, false, false, "DATE", "participantData",
@@ -163,13 +176,14 @@ public class FilterTest {
                 new NameValue("PARTICIPANT_DEATH_DATE", "2040-10-30"), null, null, null);
         List<ParticipantDataDto> allParticipantData = participantDataDao
                 .getParticipantDataByInstanceId(Integer.parseInt(String.valueOf(ddpInstanceDto.getDdpInstanceId())));
-        FilterRoute.addParticipantDataFilters(queryConditions, filterA, filterA.getFilter1().getName(), allParticipantData);
-        FilterRoute.addParticipantDataFilters(queryConditions, filterB, filterB.getFilter1().getName(), allParticipantData);
-        FilterRoute.addParticipantDataFilters(queryConditions, filterC, filterC.getFilter1().getName(), allParticipantData);
-        Assert.assertEquals("null AND (profile.guid = RBMJW6ZIXVXBMXUX6M3Q" + " OR profile.guid = " + participantId1 + ")" +
-                        " AND (profile.guid = RBMJW6ZIXVXBMXUX6M3Q" + " OR profile.guid = " + participantId1 + ")" +
-                        " AND (profile.guid = RBMJW6ZIXVXBMXUX6M3Q" + " OR profile.guid = " + participantId1 + ")",
+        FilterRoute.addParticipantDataIdsForFilters(filterA, filterA.getFilter1().getName(), allParticipantData, allParticipantDataForFiltering);
+        FilterRoute.addParticipantDataIdsForFilters(filterB, filterB.getFilter1().getName(), allParticipantData, allParticipantDataForFiltering);
+        FilterRoute.addParticipantDataIdsForFilters(filterC, filterC.getFilter1().getName(), allParticipantData, allParticipantDataForFiltering);
+        FilterRoute.addParticipantDataConditionsToQuery(allParticipantDataForFiltering, queryConditions, 3);
+        FilterRoute.addParticipantDataConditionsToQuery(allParticipantDataForFiltering, queryConditions1, 1);
+        Assert.assertEquals("null AND (profile.guid = RBMJW6ZIXVXBMXUX6M3Q" + " OR profile.guid = " + participantId1 + ")",
                 queryConditions.get(ElasticSearchUtil.ES));
+        Assert.assertEquals("null AND ()", queryConditions1.get(ElasticSearchUtil.ES));
     }
 
     @AfterClass

--- a/src/test/java/org/broadinstitute/dsm/FilterTest.java
+++ b/src/test/java/org/broadinstitute/dsm/FilterTest.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsm;
 
 import com.google.gson.Gson;
-import jnr.ffi.annotations.In;
 import org.broadinstitute.dsm.db.dto.user.UserDto;
 import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
 import org.broadinstitute.dsm.db.dao.ddp.participant.ParticipantDataDao;


### PR DESCRIPTION
Logic explanation:
Previously for each of the filter related to dynamic forms we were getting separate AND group of guids like this: AND (guid1 or guid2) AND (guid3 or guid1 or guid 2) AND ... Added hashmap to use the fact that  AND (guid1 or guid2) AND (guid3 or guid1 or guid 2) = AND (guid1 or guid2). So currently for all the filter related to dynamic filds we are getting only one AND group with guids separated by OR inside it. So implemented changes in addParticipantDataFilters and introduced a new method as well.

After that in ParticipantWrapper we needed to divide this AND group if it had too many guid, but we might also have other AND groups not related to dynamic fields, so I'm using the fact that AND (bool1) AND (bool2) AND (bool3 or bool4) = ((bool1) AND (bool2) AND (bool3)) OR ((bool1) AND (bool2) AND (bool4)). So we are dividing the large AND group of participantIds and query one by one with other conditions and add the participants. After that send back those participants.

Filter change alert: will need to be tested again after it's reviewed, corrected and merged