### PR TITLE
hotfix for filter exception about AND ()

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/model/filter/participant/BaseFilterParticipantList.java
+++ b/src/main/java/org/broadinstitute/dsm/model/filter/participant/BaseFilterParticipantList.java
@@ -114,12 +114,8 @@ public abstract class BaseFilterParticipantList extends BaseFilter implements Fi
     }
 
     public void addParticipantDataConditionsToQuery(Map<String, Integer> allIdsForParticipantDataFiltering, Map<String, String> queryConditions, int filtersLength) {
-        if (allIdsForParticipantDataFiltering.isEmpty()) {
-            queryConditions.put(ElasticSearchUtil.ES, ElasticSearchUtil.BY_PROFILE_GUID + ElasticSearchUtil.EMPTY);
-        } else {
-            String newCondition = createNewConditionByIds(allIdsForParticipantDataFiltering, filtersLength);
-            queryConditions.merge(ElasticSearchUtil.ES, newCondition, (prev, next) -> prev + next);
-        }
+        String newCondition = createNewConditionByIds(allIdsForParticipantDataFiltering, filtersLength);
+        queryConditions.merge(ElasticSearchUtil.ES, newCondition, (prev, next) -> prev + next);
     }
 
     public String createNewConditionByIds(Map<String, Integer> allIdsForParticipantDataFiltering, int filtersLength) {
@@ -135,6 +131,9 @@ public abstract class BaseFilterParticipantList extends BaseFilter implements Fi
                 newCondition.append(ParticipantUtil.isGuid(entry.getKey()) ? ElasticSearchUtil.BY_GUIDS + entry.getKey() : ElasticSearchUtil.BY_LEGACY_ALTPIDS + entry.getKey());
             }
             i++;
+        }
+        if (i == 0) {
+            newCondition.append(ElasticSearchUtil.BY_PROFILE_GUID + ElasticSearchUtil.EMPTY);
         }
         newCondition.append(ElasticSearchUtil.CLOSING_PARENTHESIS);
         return newCondition.toString();


### PR DESCRIPTION
We are checking participant guid or altpid only in case it was added to our map as many times as there are filters related to participantData. Previously if we had participants in map, which were added less times than number of participantData related filters we would get AND (), but now we will get AND (profile.guid = empty) as it was planned before.