### PR TITLE
Ignorefile updates & dependency cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,10 @@ logs
 *.jks
 /config/
 /appengine/deploy/config/
+
+# Visual Studio Code Workspace
+.vscode/
+.factorypath
+
+# asdf configuration
+.tool-versions

--- a/pom.xml
+++ b/pom.xml
@@ -216,13 +216,7 @@
             <artifactId>jaxb-api</artifactId>
             <version>2.3.0</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api -->
-        <dependency>
 
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.0-b170201.1204</version>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/javax.activation/activation -->
         <dependency>
             <groupId>javax.activation</groupId>
@@ -230,11 +224,6 @@
             <version>1.1</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.0-b170127.1453</version>
-        </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>


### PR DESCRIPTION
## Description
This PR includes the following changes:

* Removes duplicate Maven dependency elements for `javax.xml.bind:jaxb-api`, and `org.glassfish.jaxb:jaxb-runtime`. The dependencies have been retargeted to the nearest stable dot release (`2.3.0` and `2.3.2`, respectively).
* VSCode's workspace files should be ignored
* asdf's `.tool-versions` file should be ignored

## Testing
Run `mvn clean install -U -DskipTests` and ensure that the build successfully completes.