### PR TITLE
DDP-6939 - fix date format error on DDP kit receipt page

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/model/BSPKit.java
+++ b/src/main/java/org/broadinstitute/dsm/model/BSPKit.java
@@ -13,10 +13,10 @@ import org.broadinstitute.dsm.model.bsp.BSPKitInfo;
 import org.broadinstitute.dsm.model.bsp.BSPKitStatus;
 import org.broadinstitute.dsm.statics.ApplicationConfigConstants;
 import org.broadinstitute.dsm.statics.ESObjectConstants;
+import org.broadinstitute.dsm.util.ElasticSearchDataUtil;
 import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.EventUtil;
 import org.broadinstitute.dsm.util.NotificationUtil;
-import org.broadinstitute.dsm.util.SystemUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -139,7 +139,7 @@ public class BSPKit {
     private void writeSampleReceivedToES(DDPInstance ddpInstance, BSPKitDto bspKitInfo) {
         String kitRequestId = new KitRequestDao().getKitRequestIdByBSPParticipantId(bspKitInfo.getBspParticipantId());
         Map<String, Object> nameValuesMap = new HashMap<>();
-        nameValuesMap.put(ESObjectConstants.RECEIVED, SystemUtil.getISO8601DateString());
+        ElasticSearchDataUtil.setCurrentStrictYearMonthDay(nameValuesMap, ESObjectConstants.RECEIVED);
         ElasticSearchUtil.writeSample(ddpInstance, kitRequestId, bspKitInfo.getDdpParticipantId(), ESObjectConstants.SAMPLES,
                 ESObjectConstants.KIT_REQUEST_ID, nameValuesMap);
     }

--- a/src/main/java/org/broadinstitute/dsm/route/KitStatusChangeRoute.java
+++ b/src/main/java/org/broadinstitute/dsm/route/KitStatusChangeRoute.java
@@ -121,7 +121,7 @@ public class KitStatusChangeRoute extends RequestHandler {
         int ddpInstanceId = kitRequest.getDdpInstanceId();
         DDPInstance ddpInstance = DDPInstance.getDDPInstanceById(ddpInstanceId);
         Map<String, Object> nameValuesMap = new HashMap<>();
-        nameValuesMap.put(ESObjectConstants.SENT, SystemUtil.getISO8601DateString());
+        ElasticSearchDataUtil.setCurrentStrictYearMonthDay(nameValuesMap, ESObjectConstants.SENT);
         if (ddpInstance != null && kitRequest.getDdpKitRequestId() != null && kitRequest.getDdpParticipantId() != null) {
             ElasticSearchUtil.writeSample(
                     ddpInstance,

--- a/src/main/java/org/broadinstitute/dsm/util/ElasticSearchDataUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/ElasticSearchDataUtil.java
@@ -1,0 +1,19 @@
+package org.broadinstitute.dsm.util;
+
+import java.util.Map;
+
+/**
+ * Contains util methods which could be used to assign ElasticSearch data (when updating ES indices).
+ */
+public class ElasticSearchDataUtil {
+
+    /**
+     * Set the current date as String (using format 'strict_year_month_day' which is the same as 'yyyy-MM-dd')
+     * to a specified map element.
+     * @param nameValuesMap map where to set a current date
+     * @param name  element name where to set a current date
+     */
+    public static void setCurrentStrictYearMonthDay(Map<String, Object> nameValuesMap, String name) {
+        nameValuesMap.put(name, SystemUtil.getStrictYearMonthDay());
+    }
+}

--- a/src/main/java/org/broadinstitute/dsm/util/SystemUtil.java
+++ b/src/main/java/org/broadinstitute/dsm/util/SystemUtil.java
@@ -44,6 +44,19 @@ public class SystemUtil {
         return instant.toString();
     }
 
+    /**
+     * Detects current time and converts it to String "yyyy-MM-dd".<br>
+     * This format is equivalent to ElasticSearch 'strict_year_month_day' format.<br>
+     * From the ES documentation:
+     * <pre>
+     * year_month_day or strict_year_month_day
+     * A formatter for a four digit year, two digit month of year, and two digit day of month: yyyy-MM-dd
+     * </pre>
+     */
+    public static String getStrictYearMonthDay() {
+        return new SimpleDateFormat(DATE_FORMAT).format(Date.from(Instant.now()));
+    }
+
     public static final DateTimeFormatter USUAL_DATE = new DateTimeFormatterBuilder()
             .appendPattern(DATE_FORMAT)
             .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)


### PR DESCRIPTION
Fix date format error on DDP kit receipt page.  
Fix description: when updating ES index 'participants_structured' assign samples.received, samples.sent with current date according to ES format 'strict_year_month_day' (yyyy-MM-dd).
