### PR TITLE
DDP-6681 - fix filtering of numeric values (like ages)

### DIFF
--- a/src/main/java/org/broadinstitute/dsm/db/ViewFilter.java
+++ b/src/main/java/org/broadinstitute/dsm/db/ViewFilter.java
@@ -961,7 +961,12 @@ public class ViewFilter {
                     filter.setParticipantColumn(new ParticipantColumn(path, tableName));
                 }
                 else if (Filter.TEXT.equals(filter.type) || Filter.BOOLEAN.equals(filter.type) || Filter.NUMBER.equals(filter.type)) {
-                    filter.setFilter1(new NameValue(columnName, value));
+                    if (Filter.NUMBER.equals(filter.type)
+                            && condition.contains(Filter.SMALLER_EQUALS_TRIMMED) && !arrayContains(conditions, Filter.LARGER_EQUALS_TRIMMED)) {
+                        filter.setFilter2(new NameValue(columnName, value));
+                    } else {
+                        filter.setFilter1(new NameValue(columnName, value));
+                    }
                 }
                 else if (!Filter.CHECKBOX.equals(filter.type)) {
                     if (f1) {// first in range
@@ -1000,6 +1005,15 @@ public class ViewFilter {
                 viewFilter.userId, filters.values().toArray(a), viewFilter.parent,
                 viewFilter.icon, viewFilter.quickFilterName, newQuery, null, viewFilter.realmId);
         return result;
+    }
+
+    private static boolean arrayContains(String[] arr, String str) {
+        for (String s : arr) {
+            if (s.contains(str)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static String[] getColumnTableNames(String word) {

--- a/src/main/java/org/broadinstitute/dsm/db/ViewFilter.java
+++ b/src/main/java/org/broadinstitute/dsm/db/ViewFilter.java
@@ -587,6 +587,10 @@ public class ViewFilter {
                                 value = word;
                                 type = Filter.BOOLEAN;
                                 state = 40;
+                            } else if (StringUtils.isNumeric(word)) {
+                                value = word;
+                                type = Filter.NUMBER;
+                                state = 40;
                             }
                             else {
                                 tempValue = word;
@@ -625,6 +629,8 @@ public class ViewFilter {
                             value = trimValue(word);
                             if (isValidDate(value, false)) {
                                 type = Filter.DATE;
+                            } else if (StringUtils.isNumeric(word)) {
+                                type = Filter.NUMBER;
                             }
                             state = 11;
                             break;
@@ -950,7 +956,7 @@ public class ViewFilter {
                 if (Filter.ADDITIONAL_VALUES.equals(filter.type)) {
                     filter.setParticipantColumn(new ParticipantColumn(path, tableName));
                 }
-                else if (Filter.TEXT.equals(filter.type) || Filter.BOOLEAN.equals(filter.type)) {
+                else if (Filter.TEXT.equals(filter.type) || Filter.BOOLEAN.equals(filter.type) || Filter.NUMBER.equals(filter.type)) {
                     filter.setFilter1(new NameValue(columnName, value));
                 }
                 else if (!Filter.CHECKBOX.equals(filter.type)) {

--- a/src/main/java/org/broadinstitute/dsm/model/Filter.java
+++ b/src/main/java/org/broadinstitute/dsm/model/Filter.java
@@ -131,7 +131,7 @@ public class Filter {
                     condition2 = SMALLER_EQUALS + (int) Double.parseDouble(String.valueOf(filter.getFilter2().getValue()));
                 }
                 finalQuery = query + condition + query2 + condition2 + notNullQuery;
-                if (StringUtils.isNotBlank(String.valueOf(filter.getFilter1().getValue())) && !StringUtils.isNotBlank(String.valueOf(filter.getFilter2().getValue()))) {
+                if (isNotEmpty(filter.getFilter1()) || isNotEmpty(filter.getFilter2())) {
                     finalQuery = finalQuery + notNullQuery;
                 }
             }
@@ -266,6 +266,10 @@ public class Filter {
 
         //        logger.info(finalQuery);
         return finalQuery;
+    }
+
+    private static boolean isNotEmpty(NameValue filter) {
+        return filter != null && StringUtils.isNotBlank(String.valueOf(filter.getValue()));
     }
 
     private static Filter convertFilterDateValues(Filter filter) {


### PR DESCRIPTION
Fix filtering of numeric values (like ages): fix a case when it is specified only one limit of range or both limits.
For example fixed generation of ES queries from such expressions:
`AND PREQUAL.SELF_CURRENT_AGE >= 20 AND PREQUAL.SELF_CURRENT_AGE <= 46 AND PREQUAL.SELF_CURRENT_AGE IS NOT NULL`
`AND PREQUAL.SELF_CURRENT_AGE >= 20 AND PREQUAL.SELF_CURRENT_AGE IS NOT NULL`
`AND PREQUAL.SELF_CURRENT_AGE <= 46 AND PREQUAL.SELF_CURRENT_AGE IS NOT NULL`

Without this fix the generated ES queries for numerics are invalid. Sometimes queries with numeric values caused errors and NPEs.

The fix is done as a "workaround" (trying not to touch the existing code) but in reality it would be good to do a global refactoring of filter expressions parsing and ES queries generation.