### PR TITLE
Ignorefile updates & dependency checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,10 @@ logs
 *.jks
 /config/
 /appengine/deploy/config/
+
+# Visual Studio Code Workspace
+.vscode/
+.factorypath
+
+# asdf configuration
+.tool-versions

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ appengine/deploy/vault.conf
 config/ellkay.conf
 liquibase.properties
 
+# Block ALL conf files
+*.conf
+
 src/test/resources/output
 target/
 app-deploy

--- a/.gitignore
+++ b/.gitignore
@@ -60,8 +60,9 @@ appengine/deploy/vault.conf
 config/ellkay.conf
 liquibase.properties
 
-# Block ALL conf files
+# Block ALL potential secret-containing files
 *.conf
+*.json
 
 src/test/resources/output
 target/

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
                                         <resource>
                                             <directory>${project.build.directory}</directory>
                                             <includes>
-                                                <include>${build.finalName}.jar</include>
+                                                <include>${project.build.finalName}.jar</include>
                                                 <include>libs/**</include>
                                             </includes>
                                             <filtering>false</filtering>

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
             <artifactId>jruby-complete</artifactId>
             <version>9.1.15.0</version>
         </dependency>
+
         <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -124,6 +125,7 @@
             <artifactId>lombok</artifactId>
             <version>1.18.12</version>
         </dependency>
+
         <!-- liquibase -->
         <dependency>
             <groupId>org.liquibase</groupId>
@@ -370,8 +372,8 @@
         </profile>
     </profiles>
     <build>
-            <sourceDirectory>src/main/java</sourceDirectory>
-            <testSourceDirectory>src/test/java</testSourceDirectory>
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <testSourceDirectory>src/test/java</testSourceDirectory>
     </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -178,16 +178,6 @@
             <version>2.0.0</version>
         </dependency>
         <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-            <version>1.4.01</version>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>2.3.2</version>
-        </dependency>
-        <dependency>
             <groupId>xerces</groupId>
             <artifactId>xerces</artifactId>
             <version>2.4.0</version>
@@ -202,19 +192,36 @@
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
             <version>2.12.1</version>
+            <exclusions>
+                <!--
+                    Excluded to avoid conflicts with the javax.xml.* and org.w3c.dom.* modules.
+                    JDK 11 includes Xerces already (11.0.5 includes Xerces 2.12.0) so modules can clash
+                    here. If using the `xml-apis` dependency is a requirement, work will need to be
+                    done to modularize the project so a module-info.java can be used to specify
+                    the specific implementation.                   
+                -->
+                <exclusion>
+                    <artifactId>xml-apis</artifactId>
+                    <groupId>xml-apis</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
-        <!-- Runtime, com.sun.xml.bind module -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <version>2.3.2</version>
         </dependency>
-
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.3.0</version>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/javax.activation/activation -->
@@ -353,14 +360,6 @@
                         <artifactId>maven-compiler-plugin</artifactId>
                         <version>3.8.0</version>
                         <configuration>
-                            <release>11</release>
-                            <annotationProcessorPaths>
-                                <path>
-                                    <groupId>org.projectlombok</groupId>
-                                    <artifactId>lombok</artifactId>
-                                    <version>1.18.12</version>
-                                </path>
-                            </annotationProcessorPaths>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,12 @@
             <artifactId>jnanoid</artifactId>
             <version>2.0.0</version>
         </dependency>
+             
+        <!--
+            With JDK11 including Xerces 2.12.0 as the reference JAXP implementation, this dependency is no longer needed.
+            Removing the dependency could impact TestBoston, however, so wait to remove the dependency until TestBoston
+            wraps up, and the team has more time to validate the change.
+        -->
         <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -216,13 +216,7 @@
             <artifactId>jaxb-api</artifactId>
             <version>2.3.0</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api -->
-        <dependency>
 
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.0-b170201.1204</version>
-        </dependency>
         <!-- https://mvnrepository.com/artifact/javax.activation/activation -->
         <dependency>
             <groupId>javax.activation</groupId>
@@ -230,11 +224,6 @@
             <version>1.1</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.0-b170127.1453</version>
-        </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -271,6 +271,13 @@
                         <version>3.8.0</version>
                         <configuration>
                             <release>11</release>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.projectlombok</groupId>
+                                    <artifactId>lombok</artifactId>
+                                    <version>1.18.12</version>
+                                </path>
+                            </annotationProcessorPaths>
                         </configuration>
                     </plugin>
                     <plugin>
@@ -347,6 +354,13 @@
                         <version>3.8.0</version>
                         <configuration>
                             <release>11</release>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.projectlombok</groupId>
+                                    <artifactId>lombok</artifactId>
+                                    <version>1.18.12</version>
+                                </path>
+                            </annotationProcessorPaths>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -179,17 +179,6 @@
         </dependency>
         <dependency>
             <groupId>xerces</groupId>
-            <artifactId>xerces</artifactId>
-            <version>2.4.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>xerces</groupId>
-                    <artifactId>xercesImpl</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
             <version>2.12.1</version>
             <exclusions>


### PR DESCRIPTION
## Description
This PR includes the following changes:

* Removes duplicate Maven dependency elements for `javax.xml.bind:jaxb-api`, and `org.glassfish.jaxb:jaxb-runtime`. The dependencies have been retargeted to the nearest stable dot release (`2.3.0` and `2.3.2`, respectively).
* VSCode's workspace files should be ignored
* asdf's `.tool-versions` file should be ignored
* Ignore _all_ `conf` files to minimize any accidental commits
* Excluded Apache Xerces `xml-apis` dependency in order to prevent module collisions with the `javax.xml` and `org.w3c.dom` namespaces.
  * See the PR comments for more details

## Testing
Run `mvn -U -DskipTests clean package` and ensure that the build successfully completes.