### PR TITLE
Updates to DSM ReadMe [Sept 2021 Bug Bash]

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 1. [Maven 3](https://maven.apache.org/download.cgi)
 2. OpenJDK 11
 3. [gcloud CLI](https://cloud.google.com/sdk)
+4. [Homebrew](https://brew.sh/)
 ```
 brew tap homebrew/cask-versions
 brew cask install java11

--- a/README.md
+++ b/README.md
@@ -15,56 +15,54 @@ brew install maven
 ```
 
 # Setting up maven
-In addition to the usual public repos, we use github package manager for the older lddp core dependency.
+In addition to the Maven Central public repository, we use GitHub Packages' [Maven registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry)
+for the [broadinstitute/lddp-backend](https://github.com/broadinstitute/lddp-backend) dependency.
 
-To download this dependency, generate a github token and add it to your `~/.m2/settings.xml`:
+To install this dependency, [create](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+a GitHub personal access token with the `read:packages` scope, and add the token to your
+`~/.m2/settings.xml`. An example `settings.xml` file follows- replace `USERNAME` and `TOKEN` with your GitHub username and personal access token, respectively.
+```xml
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  
+  <activeProfiles>
+    <activeProfile>broad-institute</activeProfile>
+  </activeProfiles>
 
-````
-<settings>
-   
-   ...
-   
-    <activeProfiles>
-       <activeProfile>github</activeProfile>
-     </activeProfiles>
-   
-   ...
-   
-   <servers>
-       <server>
-         <id>github</id>
-         <username>...github username...</username>
-         <password>...github token...</password>
-       </server>
-     </servers>
-     
-     ...
-     
-     <profiles>
-         <profile>
-           <id>github</id>
-           <repositories>
-             <repository>
-               <id>central</id>
-               <url>https://repo1.maven.org/maven2</url>
-               <releases><enabled>true</enabled></releases>
-               <snapshots><enabled>true</enabled></snapshots>
-             </repository>
-             <repository>
-               <id>github</id>
-               <name>GitHub OWNER Apache Maven Packages</name>
-               <url>https://maven.pkg.github.com/broadinstitute/ddp-study-manager</url>
-               </repository>
-     	</repositories>
-         </profile>
-       </profiles>
-       
-       ...
-       
-       
+  <servers>
+    <server>
+      <id>github</id>
+      <username>USERNAME</username>
+      <password>TOKEN</password>
+    </server>
+  </servers>
+  
+  <profiles>
+    <profile>
+      <id>broad-institute</id>
+        <repositories>
+          <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+            <releases>
+              <enabled>true</enabled>
+            </releases>
+            <snapshots>
+              <enabled>true</enabled>
+            </snapshots>
+          </repository>
+          <repository>
+            <id>github</id>
+            <name>broadinstitute/ddp-study-manager</name>
+            <url>https://maven.pkg.github.com/broadinstitute/ddp-study-manager</url>
+          </repository>
+        </repositories>
+    </profile>
+  </profiles>
 </settings>
-
-````
+```
 
 DSM uses a single `pom.xml` but two different profile values for building the backend APIs
 for GAE and background jobs for Cloud Functions.  When building the APIs, use `-Papis`.  To 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 2. [OpenJDK 11](https://openjdk.java.net/)
 3. [gcloud CLI](https://cloud.google.com/sdk)
 4. [Homebrew](https://brew.sh/)
+5. [Lombok](https://projectlombok.org/setup/overview)
 
 ## Installing java
 Building DDP Study Manager requires the installation of both an OpenJDK 11-compatible distribution

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 2. [OpenJDK 11](https://openjdk.java.net/)
 3. [gcloud CLI](https://cloud.google.com/sdk)
 4. [Homebrew](https://brew.sh/)
+
+## Installing java
+Building DDP Study Manager requires the installation of both an OpenJDK 11-compatible distribution
+and maven. Homebrew includes packages for both, and can be installed with the commands
 ```
 brew install java11
 brew install maven

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ a GitHub personal access token with the `read:packages` scope, and add the token
 ```
 
 DSM uses a single `pom.xml` but two different profile values for building the backend APIs
-for GAE and background jobs for Cloud Functions.  When building the APIs, use `-Papis`.  To 
-build cloud functions, use `Pcloud-function`
+for GAE and background jobs for Cloud Functions.  When building the APIs, use `-Pbackend`.  To
+build cloud functions, use `-Pcloud-function`
 
 # Secrets
 DSM uses GCP's [secret manager (SM)](https://cloud.google.com/secret-manager) to store credentials.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Prerequisites
 1. [Maven 3](https://maven.apache.org/download.cgi)
-2. OpenJDK 11
+2. [OpenJDK 11](https://openjdk.java.net/)
 3. [gcloud CLI](https://cloud.google.com/sdk)
 4. [Homebrew](https://brew.sh/)
 ```

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 3. [gcloud CLI](https://cloud.google.com/sdk)
 4. [Homebrew](https://brew.sh/)
 ```
-brew tap homebrew/cask-versions
-brew cask install java11
+brew install java11
+brew install maven
 ```
 
 # Setting up maven


### PR DESCRIPTION
September 2021 Bug Bash task

This ticket updates the DSM readme to clean up several parts of the readme. The changes included are
* Update the example Maven `settings.xml` to be copy-paste friendly
* The Java 11 package was renamed in Homebrew
* Corrects the profile name of the API backend target